### PR TITLE
Decode the URI of the filepath before passing it into fs.copy

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -140,7 +140,7 @@ exports.copyObject = function (search, callback) {
 
 	fs.mkdirsSync(path.dirname(search.Bucket + '/' + search.Key));
 
-	fs.copy(search.CopySource, search.Bucket + '/' + search.Key, function (err, data) {
+	fs.copy(decodeURIComponent(search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
 
 		callback(err, search);
 	});


### PR DESCRIPTION
As the URI must be encoded on AWS, fs.copy does not support a query in an encoded form, so we decode it first before passing it on to fs.copy.