### PR TITLE
Add ability to put strings + fix tests.

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -107,6 +107,17 @@ exports.deleteObjects = function (search, callback) {
 	}
 };
 
+exports.deleteObject = function (search, callback) {
+
+	if (fs.existsSync(search.Bucket + '/' + search.Key)) {
+		fs.unlinkSync(search.Bucket + '/' + search.Key);
+		callback(null, true);
+	}
+	else {
+		callback("Error deleting object");
+	}
+};
+
 function FakeStream (search) {
     this.src = search.Bucket + '/' + search.Key;
 }

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -11,11 +11,12 @@
 var _ = require('underscore');
 var fs = require('fs-extra');
 var crypto = require('crypto');
-var path = require("path");
+var path = require('path');
+var Buffer = require('buffer').Buffer;
 
 // Gathered from http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
 exports.walk = function (dir) {
-	
+
 	var results = [];
 	var list = fs.readdirSync(dir);
 
@@ -51,7 +52,7 @@ exports.listObjects = function (search, callback) {
 	var start = 0;
 	var marker = null;
 	var truncated = false;
-	
+
 	if (search.Marker) {
 		start = filtered_files.indexOf(search.Bucket  + '/' + search.Marker);
 	}
@@ -149,6 +150,10 @@ exports.copyObject = function (search, callback) {
 exports.putObject = function (search, callback) {
 
 	var dest = search.Bucket + '/' + search.Key;
+
+	if (typeof search.Body === 'string') {
+		search.Body = new Buffer(search.Body);
+	}
 
 	if (search.Body instanceof Buffer) {
 		fs.createFileSync(dest);

--- a/test/test.js
+++ b/test/test.js
@@ -81,7 +81,7 @@ describe('S3', function () {
 			expect(data.Contents[0].Key).to.exist;
 			expect(data.IsTruncated).to.equal(true);
 			expect(data.Marker).to.exist;
-			
+
 			marker = data.Marker;
 
 			done();
@@ -99,7 +99,7 @@ describe('S3', function () {
 			expect(data.Contents[0].Key).to.exist;
 			expect(data.IsTruncated).to.equal(false);
 			expect(data.Marker).to.not.exist;
-			
+
 			marker = data.Marker;
 
 			done();
@@ -134,7 +134,7 @@ describe('S3', function () {
 			});
 		});
 	});
-    
+
     it('should fail to delete a file that does not exist', function (done) {
 
 		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 20000.txt')).to.equal(false);
@@ -161,9 +161,9 @@ describe('S3', function () {
 		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 5.txt')).to.equal(true);
 
 		var keys = [
-			{Key: '/sea/yo copy 2.txt'}, 
-			{Key: '/sea/yo copy 3.txt'}, 
-			{Key: '/sea/yo copy 4.txt'}, 
+			{Key: '/sea/yo copy 2.txt'},
+			{Key: '/sea/yo copy 3.txt'},
+			{Key: '/sea/yo copy 4.txt'},
 			{Key: '/sea/yo copy 5.txt'}
 		];
 
@@ -207,9 +207,9 @@ describe('S3', function () {
 		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 8.txt')).to.equal(true);
 
 		var keys = [
-			{Key: 'sea/yo copy 20000.txt'}, 
-			{Key: 'sea/yo copy 6.txt'}, 
-			{Key: 'sea/yo copy 7.txt'}, 
+			{Key: 'sea/yo copy 20000.txt'},
+			{Key: 'sea/yo copy 6.txt'},
+			{Key: 'sea/yo copy 7.txt'},
 			{Key: 'sea/yo copy 8.txt'}
 		];
 
@@ -252,7 +252,7 @@ describe('S3', function () {
 	it('should get a file and its content', function (done) {
 
 		s3.getObject({Key: 'animal.txt', Bucket: __dirname + '/local/otters'}, function (err, data) {
-			
+
 			expect(err).to.be.null;
 			expect(data.ETag).to.equal('"485737f20ae6c0c3e51f68dd9b93b4e9"');
 			expect(data.Key).to.equal('animal.txt');
@@ -264,18 +264,34 @@ describe('S3', function () {
 	it('should create a file and have the same content in sub dir', function (done) {
 
 		s3.putObject({Key: 'punk/file', Body: fs.readFileSync(__dirname + '/local/file'), Bucket: __dirname + '/local/otters'}, function (err, data) {
-			
+
 			expect(err).to.be.null;
 			expect(fs.existsSync(__dirname + '/local/otters/punk/file')).to.equal(true);
 
 			s3.getObject({Key: 'punk/file', Bucket: __dirname + '/local/otters'}, function (err, data) {
-				
+
 				expect(err).to.be.null;
 				expect(data.Key).to.equal('punk/file');
 				expect(data.Body.toString()).to.equal("this is a file. That's right.");
 				done();
 			});
 		});
+	});
+
+	it('should be able to put a string', function(done) {
+
+		s3.putObject({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}', Bucket: __dirname + '/local/otters'}, function(err, data) {
+			expect(err).to.be.null;
+			expect(fs.existsSync(__dirname + '/local/otters/animal.json')).to.equal(true);
+
+			s3.getObject({Key: 'animal.json', Bucket: __dirname + '/local/otters'}, function(err, data) {
+
+				expect(err).to.be.null;
+				expect(data.Key).to.equal('animal.json');
+				expect(data.Body.toString()).to.equal('{"is dog":false,"name":"otter","stringified object?":true}');
+				done();
+			})
+		})
 	});
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -147,7 +147,7 @@ describe('S3', function () {
 		s3.deleteObject(to_delete, function (err, data) {
 
 			expect(err).to.not.null;
-			expect(data).to.null;
+			expect(data).to.not.exist;
 
 			done();
 		});


### PR DESCRIPTION
The JS `aws-sdk` allows for strings to be PUT to S3 in the `putObject` method, converting them to buffers [here](https://github.com/aws/aws-sdk-js/blob/master/lib/s3/managed_upload.js#L208-L210) — this PR replicates that functionality.