### PR TITLE
listObjects Marker partial matches

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -54,7 +54,8 @@ exports.listObjects = function (search, callback) {
 	var truncated = false;
 
 	if (search.Marker) {
-		start = filtered_files.indexOf(search.Bucket  + '/' + search.Marker);
+		var startFile = _(filtered_files).find(function(file) { return file.indexOf(search.Bucket  + '/' + search.Marker) === 0});
+		start = filtered_files.indexOf(startFile);
 	}
 
 	filtered_files = _.rest(filtered_files, start);
@@ -138,7 +139,8 @@ exports.getObject = function (search, callback) {
 				callback(null, {
 					Key: search.Key,
 					ETag: '"' + crypto.createHash('md5').update(data).digest('hex') + '"',
-					Body: data
+					Body: data,
+					ContentLength: data.length
 				});
 			}
 			else {

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,21 @@ describe('S3', function () {
 		});
 	});
 
+	it('should list files starting a marker with a partial filename', function (done) {
+
+		s3.listObjects({Prefix: '', Bucket: __dirname + '/local/otters',  Marker: 'mix/yay copy 10' }, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(1000);
+			expect(data.Contents[0].ETag).to.exist;
+			expect(data.Contents[0].Key).to.equal('mix/yay copy 10.txt');
+			expect(data.Contents[0].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.IsTruncated).to.equal(true);
+			expect(data.Marker).to.exist;
+			done();
+		});
+	});
+
 	it('should list all files in bucket (more than 1000)', function (done) {
 
 		s3.listObjects({Prefix: '', Bucket: __dirname + '/local/otters'}, function (err, data) {
@@ -253,10 +268,12 @@ describe('S3', function () {
 
 		s3.getObject({Key: 'animal.txt', Bucket: __dirname + '/local/otters'}, function (err, data) {
 
+			var expectedBody = "My favourite animal";
 			expect(err).to.be.null;
 			expect(data.ETag).to.equal('"485737f20ae6c0c3e51f68dd9b93b4e9"');
 			expect(data.Key).to.equal('animal.txt');
-			expect(data.Body.toString()).to.equal("My favourite animal");
+			expect(data.Body.toString()).to.equal(expectedBody);
+			expect(data.ContentLength).to.equal(expectedBody.length);
 			done();
 		});
 	});


### PR DESCRIPTION
When listing objects on S3 the marker can be a partial match of a filename.

If you have the files:
```
bar.txt
baz.txt
foo.txt
```

`s3.listObject({Marker: 'baz'}, ...)`

Should get:

```
baz.txt
foo.txt
```

Also I added `ContentLength` to the getObject response. Since that is included in the aws-sdk as well. 
