### PR TITLE
Mock out AWS' config submodule

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -36,6 +36,10 @@ exports.walk = function (dir) {
 	return results;
 };
 
+exports.config = {
+	update: function() { }
+};
+
 exports.S3 = function (options) {
 
 	exports.endpoint = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mock-aws-s3",
   "description": "Mock AWS S3 SDK for Node.js",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "homepage": "https://github.com/MathieuLoutre/mock-aws-s3",
   "author": {
     "name": "Mathieu Triay",

--- a/test/test.js
+++ b/test/test.js
@@ -311,4 +311,9 @@ describe('S3', function () {
 		})
 	});
 
+	it('should accept "configuration"', function() {
+		expect(s3.config).to.be.ok;
+		expect(s3.config.update).to.be.a('function');
+	});
+
 });


### PR DESCRIPTION
In our application, we set some configuration for the AWS SDK at runtime, using code like:
```javascript
require("aws-sdk").config.update({"foo": "bar"});
```
This adds support for this in our mocks.