### PR TITLE
Implement the headObject API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Available:
 - deleteObjects
 - deleteObject
 - getObject
+- headObject
 - putObject
 - copyObject
 

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -144,6 +144,28 @@ FakeStream.prototype.createReadStream = function () {
     return fs.createReadStream(this.src);
 };
 
+exports.headObject = function (search, callback) {
+
+	if (!callback) {
+		return new FakeStream(search);
+	}
+	else {
+		fs.readFile(search.Bucket + '/' + search.Key, function (err, data) {
+
+			if (!err) {
+				callback(null, {
+					Key: search.Key,
+					ETag: '"' + crypto.createHash('md5').update(data).digest('hex') + '"',
+					ContentLength: data.length
+				});
+			}
+			else {
+				callback(err, search);
+			}
+		});
+	}
+};
+
 exports.getObject = function (search, callback) {
 
 	if (!callback) {

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -160,6 +160,9 @@ exports.headObject = function (search, callback) {
 				});
 			}
 			else {
+				if (err.code === 'ENOENT') {
+					err.statusCode = 404;
+				}
 				callback(err, search);
 			}
 		});

--- a/test/test.js
+++ b/test/test.js
@@ -286,6 +286,17 @@ describe('S3', function () {
 		});
 	});
 
+	it('should get the metadata about a file', function (done) {
+
+		s3.headObject({Key: 'animal.txt', Bucket: __dirname + '/local/otters'}, function (err, data) {
+
+			expect(err).to.be.null;
+			expect(data.ETag).to.equal('"485737f20ae6c0c3e51f68dd9b93b4e9"');
+			expect(data.ContentLength).to.equal(19);
+			done();
+		});
+	});
+
 	it('should get a file', function (done) {
 
 		s3.getObject({Key: 'sea/yo copy 10.txt', Bucket: __dirname + '/local/otters'}, function (err, data) {

--- a/test/test.js
+++ b/test/test.js
@@ -297,6 +297,16 @@ describe('S3', function () {
 		});
 	});
 
+	it('should include a 404 statusCode for the metadata of a non-existant file', function (done) {
+
+		s3.headObject({Key: 'doesnt-exist.txt', Bucket: __dirname + '/local/otters'}, function (err, data) {
+
+			expect(err).to.not.be.null;
+			expect(err.statusCode).to.equal(404);
+			done();
+		});
+	});
+
 	it('should get a file', function (done) {
 
 		s3.getObject({Key: 'sea/yo copy 10.txt', Bucket: __dirname + '/local/otters'}, function (err, data) {


### PR DESCRIPTION
Thank you for providing a nice mock interface to use when developing against AWS.

When porting a project of mine to use it, I found that headObject was missing.  I've provided a basic implementation.  The support in headObject matches what's available in getObject metadata.