### PR TITLE
Enable default options in the S3 mock

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,13 @@ module.exports = function(grunt) {
         options: {
           reporter: 'spec'
         },
-        src: ['test/*.js']
+        src: ['test/test.js']
+      },
+      testDefaultOptions: {
+        options: {
+          reporter: 'spec'
+        },
+        src: ['test/testDefaultOptions.js']
       }
     },
     clean: {
@@ -49,6 +55,6 @@ module.exports = function(grunt) {
 
   // By default, lint and run all tests.
   grunt.registerTask('lint', 'jshint');
-  grunt.registerTask('default', ['clean', 'copy', 'mochaTest:test']);
+  grunt.registerTask('default', ['clean', 'copy', 'mochaTest:test', 'clean', 'copy', 'mochaTest:testDefaultOptions']);
 
 };

--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ If you'd like to see some more features or you have some suggestions, feel free 
 * 2013-10-24   v0.1.2   Fix isTruncated typo
 * 2013-10-09   v0.1.1   Add LastModified to listObject
 * 2013-08-09   v0.1.0   First release
+
+## Example
+
+```
+var AWSMock = require('mock-aws-s3')
+var s3 = AWSMock.S3({
+	Bucket: '/tmp/example'
+});
+s3.putObject({Key: 'sea/animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}'}, function(err, data) {
+	s3.listObjects({Prefix: 'sea'}, function (err, data) {
+	}
+});
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Available:
 - headObject
 - putObject
 - copyObject
+- upload
 
 It uses a directory to mock a bucket and its content.
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ If you'd like to see some more features or you have some suggestions, feel free 
 
 ## Example
 
-```
-var AWSMock = require('mock-aws-s3')
+```js
+var AWSMock = require('mock-aws-s3');
 var s3 = AWSMock.S3({
 	Bucket: '/tmp/example'
 });
 s3.putObject({Key: 'sea/animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}'}, function(err, data) {
 	s3.listObjects({Prefix: 'sea'}, function (err, data) {
-	}
+		console.log(data);
+	});
 });
 ```

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -237,7 +237,12 @@ S3Mock.prototype = {
 
 			search.Body.pipe(stream);
 		}
+	},
+
+	upload: function (search, callback) {
+		return this.putObject(search, callback);
 	}
+
 };
 
 exports.S3 = function (options) {

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -15,7 +15,7 @@ var path = require('path');
 var Buffer = require('buffer').Buffer;
 
 // Gathered from http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
-exports.walk = function (dir) {
+function walk (dir) {
 
 	var results = [];
 	var list = fs.readdirSync(dir);
@@ -26,7 +26,7 @@ exports.walk = function (dir) {
 		var stat = fs.statSync(file);
 
 		if (stat && stat.isDirectory()) {
-			results = results.concat(exports.walk(file));
+			results = results.concat(walk(file));
 		}
 		else {
 			results.push(file);
@@ -34,205 +34,207 @@ exports.walk = function (dir) {
 	});
 
 	return results;
-};
+}
 
-exports.config = {
-	update: function() { }
-};
-
-exports.S3 = function (options) {
-
-	exports.endpoint = {
-		href: ''
-	};
-	return exports;
-};
-
-exports.listObjects = function (search, callback) {
-
-	var files = exports.walk(search.Bucket);
-
-	var filtered_files = _.filter(files, function (file) { return file.replace(search.Bucket + '/', '').indexOf(search.Prefix) === 0; });
-	var start = 0;
-	var marker = null;
-	var truncated = false;
-
-	if (search.Marker) {
-		var startFile = _(filtered_files).find(function(file) { return file.indexOf(search.Bucket  + '/' + search.Marker) === 0});
-		start = filtered_files.indexOf(startFile);
-	}
-
-	filtered_files = _.rest(filtered_files, start);
-
-	if (filtered_files.length > 1000) {
-		truncated = true;
-		filtered_files = filtered_files.slice(0, 1000);
-	}
-
-	var result = {
-		Contents: _.map(filtered_files, function (path) {
-
-			return {
-				Key: path.replace(search.Bucket + '/', ''),
-				ETag: '"' + crypto.createHash('md5').update(fs.readFileSync(path)).digest('hex') + '"',
-				LastModified: fs.statSync(path).mtime
-			};
-		}),
-		CommonPrefixes: _.reduce(filtered_files, function (prefixes, path) {
-			var prefix = path
-				.replace(search.Bucket + '/', '')
-				.split('/')
-				.slice(0, -1)
-				.join('/')
-				.concat('/');
-			return prefixes.indexOf(prefix) === -1 ? prefixes.concat([prefix]) : prefixes;
-		}, []).map(function(prefix) {
-			return {
-				Prefix: prefix
-			};
-		}),
-		IsTruncated: truncated
-	};
-
-	if (truncated) {
-		result.Marker = _.last(result.Contents).Key;
-	}
-
-	callback(null, result);
-};
-
-exports.deleteObjects = function (search, callback) {
-
-	var deleted = [];
-	var errors = [];
-
-	_.each(search.Delete.Objects, function (file) {
-
-		if (fs.existsSync(search.Bucket + '/' + file.Key)) {
-			deleted.push(file);
-			fs.unlinkSync(search.Bucket + '/' + file.Key);
-		}
-		else {
-			errors.push(file);
-		}
-	});
-
-	if (errors.length > 0) {
-		callback("Error deleting objects", {Errors: errors, Deleted: deleted});
-	}
-	else {
-		callback(null, {Deleted: deleted});
-	}
-};
-
-exports.deleteObject = function (search, callback) {
-
-	if (fs.existsSync(search.Bucket + '/' + search.Key)) {
-		fs.unlinkSync(search.Bucket + '/' + search.Key);
-		callback(null, true);
-	}
-	else {
-		callback("Error deleting object");
-	}
-};
-
+/** FakeStream object for mocking S3 streams */
 function FakeStream (search) {
     this.src = search.Bucket + '/' + search.Key;
 }
-
 FakeStream.prototype.createReadStream = function () {
     return fs.createReadStream(this.src);
 };
 
-exports.headObject = function (search, callback) {
+/** Mocks key pieces of the amazon s3 sdk */
+function S3Mock(options) {
+	this.defaultOptions = options;
+	this.config = {
+		update: function() {}
+	};
+}
+S3Mock.prototype = {
+	listObjects: function (search, callback) {
 
-	if (!callback) {
-		return new FakeStream(search);
-	}
-	else {
-		fs.readFile(search.Bucket + '/' + search.Key, function (err, data) {
+		var files = walk(search.Bucket);
 
-			if (!err) {
-				callback(null, {
-					Key: search.Key,
-					ETag: '"' + crypto.createHash('md5').update(data).digest('hex') + '"',
-					ContentLength: data.length
-				});
+		var filtered_files = _.filter(files, function (file) { return file.replace(search.Bucket + '/', '').indexOf(search.Prefix) === 0; });
+		var start = 0;
+		var marker = null;
+		var truncated = false;
+
+		if (search.Marker) {
+			var startFile = _(filtered_files).find(function(file) { return file.indexOf(search.Bucket  + '/' + search.Marker) === 0; });
+			start = filtered_files.indexOf(startFile);
+		}
+
+		filtered_files = _.rest(filtered_files, start);
+
+		if (filtered_files.length > 1000) {
+			truncated = true;
+			filtered_files = filtered_files.slice(0, 1000);
+		}
+
+		var result = {
+			Contents: _.map(filtered_files, function (path) {
+
+				return {
+					Key: path.replace(search.Bucket + '/', ''),
+					ETag: '"' + crypto.createHash('md5').update(fs.readFileSync(path)).digest('hex') + '"',
+					LastModified: fs.statSync(path).mtime
+				};
+			}),
+			CommonPrefixes: _.reduce(filtered_files, function (prefixes, path) {
+				var prefix = path
+					.replace(search.Bucket + '/', '')
+					.split('/')
+					.slice(0, -1)
+					.join('/')
+					.concat('/');
+				return prefixes.indexOf(prefix) === -1 ? prefixes.concat([prefix]) : prefixes;
+			}, []).map(function(prefix) {
+				return {
+					Prefix: prefix
+				};
+			}),
+			IsTruncated: truncated
+		};
+
+		if (truncated) {
+			result.Marker = _.last(result.Contents).Key;
+		}
+
+		callback(null, result);
+	},
+
+	deleteObjects: function (search, callback) {
+
+		var deleted = [];
+		var errors = [];
+
+		_.each(search.Delete.Objects, function (file) {
+
+			if (fs.existsSync(search.Bucket + '/' + file.Key)) {
+				deleted.push(file);
+				fs.unlinkSync(search.Bucket + '/' + file.Key);
 			}
 			else {
-				if (err.code === 'ENOENT') {
-					err.statusCode = 404;
-				}
-				callback(err, search);
+				errors.push(file);
 			}
 		});
-	}
-};
 
-exports.getObject = function (search, callback) {
+		if (errors.length > 0) {
+			callback("Error deleting objects", {Errors: errors, Deleted: deleted});
+		}
+		else {
+			callback(null, {Deleted: deleted});
+		}
+	},
 
-	if (!callback) {
-		return new FakeStream(search);
-	}
-	else {
-		fs.readFile(search.Bucket + '/' + search.Key, function (err, data) {
+	deleteObject: function (search, callback) {
 
-			if (!err) {
-				callback(null, {
-					Key: search.Key,
-					ETag: '"' + crypto.createHash('md5').update(data).digest('hex') + '"',
-					Body: data,
-					ContentLength: data.length
-				});
-			}
-			else {
-				callback(err, search);
-			}
-		});
-	}
-};
-
-exports.copyObject = function (search, callback) {
-
-	fs.mkdirsSync(path.dirname(search.Bucket + '/' + search.Key));
-
-	fs.copy(decodeURIComponent(search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
-
-		callback(err, search);
-	});
-};
-
-exports.putObject = function (search, callback) {
-
-	var dest = search.Bucket + '/' + search.Key;
-
-	if (typeof search.Body === 'string') {
-		search.Body = new Buffer(search.Body);
-	}
-
-	if (search.Body instanceof Buffer) {
-		fs.createFileSync(dest);
-		fs.writeFile(dest, search.Body, function (err) {
-			callback(err);
-		});
-	}
-	else {
-		fs.mkdirsSync(path.dirname(dest));
-
-		var stream = fs.createWriteStream(dest);
-
-		stream.on('finish', function () {
+		if (fs.existsSync(search.Bucket + '/' + search.Key)) {
+			fs.unlinkSync(search.Bucket + '/' + search.Key);
 			callback(null, true);
-		});
+		}
+		else {
+			callback("Error deleting object");
+		}
+	},
 
-		search.Body.on('error', function (err) {
-			callback(err);
-		});
+	headObject: function (search, callback) {
 
-		stream.on('error', function (err) {
-			callback(err);
-		});
+		if (!callback) {
+			return new FakeStream(search);
+		}
+		else {
+			fs.readFile(search.Bucket + '/' + search.Key, function (err, data) {
 
-		search.Body.pipe(stream);
+				if (!err) {
+					callback(null, {
+						Key: search.Key,
+						ETag: '"' + crypto.createHash('md5').update(data).digest('hex') + '"',
+						ContentLength: data.length
+					});
+				}
+				else {
+					if (err.code === 'ENOENT') {
+						err.statusCode = 404;
+					}
+					callback(err, search);
+				}
+			});
+		}
+	},
+
+	getObject: function (search, callback) {
+
+		if (!callback) {
+			return new FakeStream(search);
+		}
+		else {
+			fs.readFile(search.Bucket + '/' + search.Key, function (err, data) {
+
+				if (!err) {
+					callback(null, {
+						Key: search.Key,
+						ETag: '"' + crypto.createHash('md5').update(data).digest('hex') + '"',
+						Body: data,
+						ContentLength: data.length
+					});
+				}
+				else {
+					callback(err, search);
+				}
+			});
+		}
+	},
+
+	copyObject: function (search, callback) {
+
+		fs.mkdirsSync(path.dirname(search.Bucket + '/' + search.Key));
+
+		fs.copy(decodeURIComponent(search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
+
+			callback(err, search);
+		});
+	},
+
+	putObject: function (search, callback) {
+
+		var dest = search.Bucket + '/' + search.Key;
+
+		if (typeof search.Body === 'string') {
+			search.Body = new Buffer(search.Body);
+		}
+
+		if (search.Body instanceof Buffer) {
+			fs.createFileSync(dest);
+			fs.writeFile(dest, search.Body, function (err) {
+				callback(err);
+			});
+		}
+		else {
+			fs.mkdirsSync(path.dirname(dest));
+
+			var stream = fs.createWriteStream(dest);
+
+			stream.on('finish', function () {
+				callback(null, true);
+			});
+
+			search.Body.on('error', function (err) {
+				callback(err);
+			});
+
+			stream.on('error', function (err) {
+				callback(err);
+			});
+
+			search.Body.pipe(stream);
+		}
 	}
 };
+
+exports.S3 = function (options) {
+	return new S3Mock(options);
+};
+

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -53,7 +53,7 @@ function S3Mock(options) {
 }
 S3Mock.prototype = {
 	listObjects: function (search, callback) {
-
+		search = _.extend({}, this.defaultOptions, search);
 		var files = walk(search.Bucket);
 
 		var filtered_files = _.filter(files, function (file) { return file.replace(search.Bucket + '/', '').indexOf(search.Prefix) === 0; });
@@ -106,6 +106,7 @@ S3Mock.prototype = {
 	},
 
 	deleteObjects: function (search, callback) {
+		search = _.extend({}, this.defaultOptions, search);
 
 		var deleted = [];
 		var errors = [];
@@ -130,6 +131,7 @@ S3Mock.prototype = {
 	},
 
 	deleteObject: function (search, callback) {
+		search = _.extend({}, this.defaultOptions, search);
 
 		if (fs.existsSync(search.Bucket + '/' + search.Key)) {
 			fs.unlinkSync(search.Bucket + '/' + search.Key);
@@ -141,6 +143,7 @@ S3Mock.prototype = {
 	},
 
 	headObject: function (search, callback) {
+		search = _.extend({}, this.defaultOptions, search);
 
 		if (!callback) {
 			return new FakeStream(search);
@@ -166,6 +169,7 @@ S3Mock.prototype = {
 	},
 
 	getObject: function (search, callback) {
+		search = _.extend({}, this.defaultOptions, search);
 
 		if (!callback) {
 			return new FakeStream(search);
@@ -189,6 +193,7 @@ S3Mock.prototype = {
 	},
 
 	copyObject: function (search, callback) {
+		search = _.extend({}, this.defaultOptions, search);
 
 		fs.mkdirsSync(path.dirname(search.Bucket + '/' + search.Key));
 
@@ -199,6 +204,7 @@ S3Mock.prototype = {
 	},
 
 	putObject: function (search, callback) {
+		search = _.extend({}, this.defaultOptions, search);
 
 		var dest = search.Bucket + '/' + search.Key;
 

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -138,7 +138,7 @@ S3Mock.prototype = {
 			callback(null, true);
 		}
 		else {
-			callback("Error deleting object");
+			callback(null, {});
 		}
 	},
 

--- a/test/test.js
+++ b/test/test.js
@@ -365,6 +365,22 @@ describe('S3', function () {
 		})
 	});
 
+	it('should be able to upload a string', function(done) {
+
+		s3.upload({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true,"upload":true}', Bucket: __dirname + '/local/otters'}, function(err, data) {
+			expect(err).to.be.null;
+			expect(fs.existsSync(__dirname + '/local/otters/animal.json')).to.equal(true);
+
+			s3.getObject({Key: 'animal.json', Bucket: __dirname + '/local/otters'}, function(err, data) {
+
+				expect(err).to.be.null;
+				expect(data.Key).to.equal('animal.json');
+				expect(data.Body.toString()).to.equal('{"is dog":false,"name":"otter","stringified object?":true,"upload":true}');
+				done();
+			})
+		})
+	});
+
 	it('should accept "configuration"', function() {
 		expect(s3.config).to.be.ok;
 		expect(s3.config.update).to.be.a('function');

--- a/test/test.js
+++ b/test/test.js
@@ -180,7 +180,7 @@ describe('S3', function () {
 		});
 	});
 
-    it('should fail to delete a file that does not exist', function (done) {
+  it('should not error when deleting a file that does not exist', function (done) {
 
 		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 20000.txt')).to.equal(false);
 
@@ -191,8 +191,8 @@ describe('S3', function () {
 
 		s3.deleteObject(to_delete, function (err, data) {
 
-			expect(err).to.not.null;
-			expect(data).to.not.exist;
+			expect(err).to.null;
+			expect(data).to.exist;
 
 			done();
 		});

--- a/test/testDefaultOptions.js
+++ b/test/testDefaultOptions.js
@@ -193,8 +193,8 @@ describe('S3 with defaultOptions', function () {
 
 		s3.deleteObject(to_delete, function (err, data) {
 
-			expect(err).to.not.null;
-			expect(data).to.not.exist;
+			expect(err).to.null;
+			expect(data).to.exist;
 
 			done();
 		});

--- a/test/testDefaultOptions.js
+++ b/test/testDefaultOptions.js
@@ -1,0 +1,375 @@
+var expect = require('chai').expect;
+var AWS = require('../');
+var fs = require('fs');
+
+describe('S3 with defaultOptions', function () {
+
+	var s3 = AWS.S3({
+		Bucket: __dirname + '/local/otters'
+	});
+	var marker = null;
+
+	it('should list files in bucket with less than 1000 objects and use Prefix to filter', function (done) {
+
+		s3.listObjects({Prefix: 'sea/'}, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(560);
+			expect(data.Contents[1].ETag).to.exist;
+			expect(data.Contents[1].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.Contents[1].Key).to.exist;
+			expect(data.CommonPrefixes.length).to.equal(1);
+			expect(data.CommonPrefixes[0].Prefix).to.exist;
+			expect(data.CommonPrefixes[0].Prefix).to.equal('sea/');
+			expect(data.IsTruncated).to.equal(false);
+			expect(data.Marker).to.not.exist;
+			done();
+		});
+	});
+
+	it('should list files in bucket with less than 1000 objects and use Prefix to filter - 2', function (done) {
+
+		s3.listObjects({Prefix: 'river/'}, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(912);
+			expect(data.Contents[1].ETag).to.exist;
+			expect(data.Contents[1].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.Contents[1].Key).to.exist;
+			expect(data.CommonPrefixes.length).to.equal(1);
+			expect(data.CommonPrefixes[0].Prefix).to.exist;
+			expect(data.CommonPrefixes[0].Prefix).to.equal('river/');
+			expect(data.IsTruncated).to.equal(false);
+			expect(data.Marker).to.not.exist;
+			done();
+		});
+	});
+
+	it('should list files in bucket with more than 1000 objects and use Prefix to filter - 3', function (done) {
+
+		s3.listObjects({Prefix: 'mix/'}, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(1000);
+			expect(data.Contents[1].ETag).to.exist;
+			expect(data.Contents[1].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.Contents[1].Key).to.exist;
+			expect(data.CommonPrefixes.length).to.equal(1);
+			expect(data.CommonPrefixes[0].Prefix).to.exist;
+			expect(data.CommonPrefixes[0].Prefix).to.equal('mix/');
+			expect(data.IsTruncated).to.equal(true);
+			expect(data.Marker).to.exist;
+			done();
+		});
+	});
+
+	it('should list files starting a marker with a partial filename', function (done) {
+
+		s3.listObjects({Prefix: '',  Marker: 'mix/yay copy 10' }, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(1000);
+			expect(data.Contents[0].ETag).to.exist;
+			expect(data.Contents[0].Key).to.equal('mix/yay copy 10.txt');
+			expect(data.Contents[0].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.CommonPrefixes.length).to.equal(1);
+			expect(data.CommonPrefixes[0].Prefix).to.exist;
+			expect(data.CommonPrefixes[0].Prefix).to.equal('mix/');
+			expect(data.IsTruncated).to.equal(true);
+			expect(data.Marker).to.exist;
+			done();
+		});
+	});
+
+	it('should list all files in bucket (more than 1000)', function (done) {
+
+		s3.listObjects({Prefix: ''}, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(1000);
+			expect(data.Contents[1].ETag).to.exist;
+			expect(data.Contents[1].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.Contents[1].Key).to.exist;
+			expect(data.CommonPrefixes.length).to.equal(2);
+			expect(data.CommonPrefixes[0].Prefix).to.exist;
+			expect(data.CommonPrefixes[0].Prefix).to.equal('/');
+			expect(data.CommonPrefixes[1].Prefix).to.exist;
+			expect(data.CommonPrefixes[1].Prefix).to.equal('mix/');
+			expect(data.IsTruncated).to.equal(true);
+			expect(data.Marker).to.exist;
+
+			marker = data.Marker;
+
+			done();
+		});
+	});
+
+	it('should list more files in bucket (more than 1000) with marker', function (done) {
+
+		s3.listObjects({Prefix: '', Marker: marker}, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(1000);
+			expect(data.Contents[0].ETag).to.exist;
+			expect(data.Contents[0].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.Contents[0].Key).to.exist;
+			expect(data.CommonPrefixes.length).to.equal(2);
+			expect(data.CommonPrefixes[0].Prefix).to.exist;
+			expect(data.CommonPrefixes[0].Prefix).to.equal('mix/');
+			expect(data.CommonPrefixes[1].Prefix).to.exist;
+			expect(data.CommonPrefixes[1].Prefix).to.equal('river/');
+			expect(data.IsTruncated).to.equal(true);
+			expect(data.Marker).to.exist;
+
+			marker = data.Marker;
+
+			done();
+		});
+	});
+
+	it('should list more files in bucket (more than 1000) with marker - 2', function (done) {
+
+		s3.listObjects({Prefix: '', Marker: marker}, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(947);
+			expect(data.Contents[0].ETag).to.exist;
+			expect(data.Contents[0].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.Contents[0].Key).to.exist;
+			expect(data.CommonPrefixes.length).to.equal(2);
+			expect(data.CommonPrefixes[0].Prefix).to.exist;
+			expect(data.CommonPrefixes[0].Prefix).to.equal('river/');
+			expect(data.CommonPrefixes[1].Prefix).to.exist;
+			expect(data.CommonPrefixes[1].Prefix).to.equal('sea/');
+			expect(data.IsTruncated).to.equal(false);
+			expect(data.Marker).to.not.exist;
+
+			marker = data.Marker;
+
+			done();
+		});
+	});
+
+	it('should delete the specified file', function (done) {
+
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy.txt')).to.equal(true);
+
+		var to_delete = {
+			Key: '/sea/yo copy.txt',
+
+		};
+
+		s3.deleteObject(to_delete, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data).to.exist;
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy.txt')).to.equal(false);
+
+			s3.listObjects({Prefix: 'sea'}, function (err, data) {
+
+				expect(err).to.equal(null);
+				expect(data.Contents.length).to.equal(559);
+				expect(data.Contents[0].ETag).to.exist;
+				expect(data.Contents[0].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+				expect(data.Contents[0].Key).to.exist;
+				expect(data.CommonPrefixes.length).to.equal(1);
+				expect(data.CommonPrefixes[0].Prefix).to.exist;
+				expect(data.CommonPrefixes[0].Prefix).to.equal('sea/');
+				expect(data.IsTruncated).to.equal(false);
+				expect(data.Marker).to.not.exist;
+				done();
+			});
+		});
+	});
+
+    it('should fail to delete a file that does not exist', function (done) {
+
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 20000.txt')).to.equal(false);
+
+		var to_delete = {
+			Key: '/sea/yo copy 20000.txt',
+
+		};
+
+		s3.deleteObject(to_delete, function (err, data) {
+
+			expect(err).to.not.null;
+			expect(data).to.not.exist;
+
+			done();
+		});
+	});
+
+    it('should delete the specified files', function (done) {
+
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 2.txt')).to.equal(true);
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 3.txt')).to.equal(true);
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 4.txt')).to.equal(true);
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 5.txt')).to.equal(true);
+
+		var keys = [
+			{Key: '/sea/yo copy 2.txt'},
+			{Key: '/sea/yo copy 3.txt'},
+			{Key: '/sea/yo copy 4.txt'},
+			{Key: '/sea/yo copy 5.txt'}
+		];
+
+		var to_delete = {
+			Delete: {
+				Objects: keys
+			},
+
+		};
+
+		s3.deleteObjects(to_delete, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Deleted).to.exist;
+			expect(data.Deleted.length).to.equal(4);
+			expect(data.Deleted).to.deep.equal(keys);
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 2.txt')).to.equal(false);
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 3.txt')).to.equal(false);
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 4.txt')).to.equal(false);
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 5.txt')).to.equal(false);
+
+			s3.listObjects({Prefix: 'sea'}, function (err, data) {
+
+				expect(err).to.equal(null);
+				expect(data.Contents.length).to.equal(555);
+				expect(data.Contents[0].ETag).to.exist;
+				expect(data.Contents[0].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+				expect(data.Contents[0].Key).to.exist;
+				expect(data.CommonPrefixes.length).to.equal(1);
+				expect(data.CommonPrefixes[0].Prefix).to.exist;
+				expect(data.CommonPrefixes[0].Prefix).to.equal('sea/');
+				expect(data.IsTruncated).to.equal(false);
+				expect(data.Marker).to.not.exist;
+				done();
+			});
+		});
+	});
+
+	it('should delete the specified files with a file that does not exist', function (done) {
+
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 20000.txt')).to.equal(false);
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 6.txt')).to.equal(true);
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 7.txt')).to.equal(true);
+		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 8.txt')).to.equal(true);
+
+		var keys = [
+			{Key: 'sea/yo copy 20000.txt'},
+			{Key: 'sea/yo copy 6.txt'},
+			{Key: 'sea/yo copy 7.txt'},
+			{Key: 'sea/yo copy 8.txt'}
+		];
+
+		var to_delete = {
+			Delete: {
+				Objects: keys
+			},
+
+		};
+
+		s3.deleteObjects(to_delete, function (err, data) {
+
+			expect(err).to.not.be.null;
+			expect(data.Errors).to.exist;
+			expect(data.Deleted).to.exist;
+			expect(data.Errors.length).to.equal(1);
+			expect(data.Deleted.length).to.equal(3);
+			expect(data.Errors[0].Key).to.equal('sea/yo copy 20000.txt');
+
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 20000.txt')).to.equal(false);
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 6.txt')).to.equal(false);
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 7.txt')).to.equal(false);
+			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 8.txt')).to.equal(false);
+
+			done();
+		});
+	});
+
+	it('should get the metadata about a file', function (done) {
+
+		s3.headObject({Key: 'animal.txt'}, function (err, data) {
+
+			expect(err).to.be.null;
+			expect(data.ETag).to.equal('"485737f20ae6c0c3e51f68dd9b93b4e9"');
+			expect(data.ContentLength).to.equal(19);
+			done();
+		});
+	});
+
+	it('should include a 404 statusCode for the metadata of a non-existant file', function (done) {
+
+		s3.headObject({Key: 'doesnt-exist.txt'}, function (err, data) {
+
+			expect(err).to.not.be.null;
+			expect(err.statusCode).to.equal(404);
+			done();
+		});
+	});
+
+	it('should get a file', function (done) {
+
+		s3.getObject({Key: 'sea/yo copy 10.txt'}, function (err, data) {
+
+			expect(err).to.be.null;
+			expect(data.ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.Key).to.equal('sea/yo copy 10.txt');
+			done();
+		});
+	});
+
+	it('should get a file and its content', function (done) {
+
+		s3.getObject({Key: 'animal.txt'}, function (err, data) {
+
+			var expectedBody = "My favourite animal";
+			expect(err).to.be.null;
+			expect(data.ETag).to.equal('"485737f20ae6c0c3e51f68dd9b93b4e9"');
+			expect(data.Key).to.equal('animal.txt');
+			expect(data.Body.toString()).to.equal(expectedBody);
+			expect(data.ContentLength).to.equal(expectedBody.length);
+			done();
+		});
+	});
+
+	it('should create a file and have the same content in sub dir', function (done) {
+
+		s3.putObject({Key: 'punk/file', Body: fs.readFileSync(__dirname + '/local/file')}, function (err, data) {
+
+			expect(err).to.be.null;
+			expect(fs.existsSync(__dirname + '/local/otters/punk/file')).to.equal(true);
+
+			s3.getObject({Key: 'punk/file'}, function (err, data) {
+
+				expect(err).to.be.null;
+				expect(data.Key).to.equal('punk/file');
+				expect(data.Body.toString()).to.equal("this is a file. That's right.");
+				done();
+			});
+		});
+	});
+
+	it('should be able to put a string', function(done) {
+
+		s3.putObject({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}'}, function(err, data) {
+			expect(err).to.be.null;
+			expect(fs.existsSync(__dirname + '/local/otters/animal.json')).to.equal(true);
+
+			s3.getObject({Key: 'animal.json'}, function(err, data) {
+
+				expect(err).to.be.null;
+				expect(data.Key).to.equal('animal.json');
+				expect(data.Body.toString()).to.equal('{"is dog":false,"name":"otter","stringified object?":true}');
+				done();
+			})
+		})
+	});
+
+	it('should accept "configuration"', function() {
+		expect(s3.config).to.be.ok;
+		expect(s3.config.update).to.be.a('function');
+	});
+
+});


### PR DESCRIPTION
The S3 api lets you set "map of parameters to bind to every request sent by this service object" in the constructor.
See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property

I'm calling these parameters "default options."

This pull requests enables the default options functionality.  This required me to refactor mock.js into an instantiable object so each instance could have its own set of default options.  Unfortunately I had to touch a majority of mock.js and github doesn't ignore white space so the diff looks a lot bigger than it really is.  It might be easier to just look at mock.js than compare the diff (https://github.com/qualtrics/mock-aws-s3/blob/master/lib/mock.js)

I added a new suite of tests testDefaultOptions.js to verify the new functionality.  test.js was left completely untouched so this should not be a breaking change.

