### PR TITLE
Set NextMarker and Marker according to AWS spec for listObjects.

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -58,7 +58,6 @@ S3Mock.prototype = {
 
 		var filtered_files = _.filter(files, function (file) { return file.replace(search.Bucket + '/', '').indexOf(search.Prefix) === 0; });
 		var start = 0;
-		var marker = null;
 		var truncated = false;
 
 		if (search.Marker) {
@@ -98,8 +97,11 @@ S3Mock.prototype = {
 			IsTruncated: truncated
 		};
 
-		if (truncated) {
-			result.Marker = _.last(result.Contents).Key;
+		if (search.Marker) {
+                        result.Marker = search.Marker;
+                }
+		if (truncated && search.Delimiter) {
+			result.NextMarker = _.last(result.Contents).Key;
 		}
 
 		callback(null, result);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mock-aws-s3",
   "description": "Mock AWS S3 SDK for Node.js",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "homepage": "https://github.com/MathieuLoutre/mock-aws-s3",
   "author": {
     "name": "Mathieu Triay",

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,7 @@ describe('S3', function () {
 			expect(data.CommonPrefixes[0].Prefix).to.equal('sea/');
 			expect(data.IsTruncated).to.equal(false);
 			expect(data.Marker).to.not.exist;
+			expect(data.NextMarker).to.not.exist;
 			done();
 		});
 	});
@@ -39,13 +40,15 @@ describe('S3', function () {
 			expect(data.CommonPrefixes[0].Prefix).to.equal('river/');
 			expect(data.IsTruncated).to.equal(false);
 			expect(data.Marker).to.not.exist;
+			expect(data.NextMarker).to.not.exist;
 			done();
 		});
 	});
 
 	it('should list files in bucket with more than 1000 objects and use Prefix to filter - 3', function (done) {
 
-		s3.listObjects({Prefix: 'mix/', Bucket: __dirname + '/local/otters'}, function (err, data) {
+		s3.listObjects({Prefix: 'mix/', Bucket: __dirname + '/local/otters', Delimiter:'/'},
+                               function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -56,14 +59,16 @@ describe('S3', function () {
 			expect(data.CommonPrefixes[0].Prefix).to.exist;
 			expect(data.CommonPrefixes[0].Prefix).to.equal('mix/');
 			expect(data.IsTruncated).to.equal(true);
-			expect(data.Marker).to.exist;
+			expect(data.Marker).to.not.exist;
+			expect(data.NextMarker).to.exist;
 			done();
 		});
 	});
 
 	it('should list files starting a marker with a partial filename', function (done) {
 
-		s3.listObjects({Prefix: '', Bucket: __dirname + '/local/otters',  Marker: 'mix/yay copy 10' }, function (err, data) {
+		s3.listObjects({Prefix: '', Bucket: __dirname + '/local/otters',  Marker: 'mix/yay copy 10',
+                                Delimiter:'/' }, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -75,13 +80,14 @@ describe('S3', function () {
 			expect(data.CommonPrefixes[0].Prefix).to.equal('mix/');
 			expect(data.IsTruncated).to.equal(true);
 			expect(data.Marker).to.exist;
+			expect(data.NextMarker).to.exist;
 			done();
 		});
 	});
 
 	it('should list all files in bucket (more than 1000)', function (done) {
 
-		s3.listObjects({Prefix: '', Bucket: __dirname + '/local/otters'}, function (err, data) {
+		s3.listObjects({Prefix: '', Bucket: __dirname + '/local/otters', Delimiter:'/'}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -94,9 +100,10 @@ describe('S3', function () {
 			expect(data.CommonPrefixes[1].Prefix).to.exist;
 			expect(data.CommonPrefixes[1].Prefix).to.equal('mix/');
 			expect(data.IsTruncated).to.equal(true);
-			expect(data.Marker).to.exist;
+			expect(data.Marker).to.not.exist;
+			expect(data.NextMarker).to.exist;
 
-			marker = data.Marker;
+			marker = data.NextMarker;
 
 			done();
 		});
@@ -104,7 +111,8 @@ describe('S3', function () {
 
 	it('should list more files in bucket (more than 1000) with marker', function (done) {
 
-		s3.listObjects({Prefix: '', Marker: marker, Bucket: __dirname + '/local/otters'}, function (err, data) {
+		s3.listObjects({Prefix: '', Marker: marker, Bucket: __dirname + '/local/otters', Delimiter:'/'},
+                               function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -118,8 +126,9 @@ describe('S3', function () {
 			expect(data.CommonPrefixes[1].Prefix).to.equal('river/');
 			expect(data.IsTruncated).to.equal(true);
 			expect(data.Marker).to.exist;
+			expect(data.NextMarker).to.exist;
 
-			marker = data.Marker;
+			marker = data.NextMarker;
 
 			done();
 		});
@@ -127,7 +136,8 @@ describe('S3', function () {
 
 	it('should list more files in bucket (more than 1000) with marker - 2', function (done) {
 
-		s3.listObjects({Prefix: '', Marker: marker, Bucket: __dirname + '/local/otters'}, function (err, data) {
+		s3.listObjects({Prefix: '', Marker: marker, Bucket: __dirname + '/local/otters', Delimiter:'/'},
+                               function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(947);
@@ -140,9 +150,10 @@ describe('S3', function () {
 			expect(data.CommonPrefixes[1].Prefix).to.exist;
 			expect(data.CommonPrefixes[1].Prefix).to.equal('sea/');
 			expect(data.IsTruncated).to.equal(false);
-			expect(data.Marker).to.not.exist;
+			expect(data.Marker).to.exist;
+			expect(data.NextMarker).to.not.exist;
 
-			marker = data.Marker;
+			marker = data.NextMarker;
 
 			done();
 		});

--- a/test/testDefaultOptions.js
+++ b/test/testDefaultOptions.js
@@ -5,7 +5,8 @@ var fs = require('fs');
 describe('S3 with defaultOptions', function () {
 
 	var s3 = AWS.S3({
-		Bucket: __dirname + '/local/otters'
+		Bucket: __dirname + '/local/otters',
+                Delimiter: '/'
 	});
 	var marker = null;
 
@@ -23,6 +24,7 @@ describe('S3 with defaultOptions', function () {
 			expect(data.CommonPrefixes[0].Prefix).to.equal('sea/');
 			expect(data.IsTruncated).to.equal(false);
 			expect(data.Marker).to.not.exist;
+			expect(data.NextMarker).to.not.exist;
 			done();
 		});
 	});
@@ -41,6 +43,7 @@ describe('S3 with defaultOptions', function () {
 			expect(data.CommonPrefixes[0].Prefix).to.equal('river/');
 			expect(data.IsTruncated).to.equal(false);
 			expect(data.Marker).to.not.exist;
+			expect(data.NextMarker).to.not.exist;
 			done();
 		});
 	});
@@ -58,7 +61,8 @@ describe('S3 with defaultOptions', function () {
 			expect(data.CommonPrefixes[0].Prefix).to.exist;
 			expect(data.CommonPrefixes[0].Prefix).to.equal('mix/');
 			expect(data.IsTruncated).to.equal(true);
-			expect(data.Marker).to.exist;
+			expect(data.Marker).to.not.exist;
+			expect(data.NextMarker).to.exist;
 			done();
 		});
 	});
@@ -77,6 +81,7 @@ describe('S3 with defaultOptions', function () {
 			expect(data.CommonPrefixes[0].Prefix).to.equal('mix/');
 			expect(data.IsTruncated).to.equal(true);
 			expect(data.Marker).to.exist;
+			expect(data.NextMarker).to.exist;
 			done();
 		});
 	});
@@ -96,9 +101,10 @@ describe('S3 with defaultOptions', function () {
 			expect(data.CommonPrefixes[1].Prefix).to.exist;
 			expect(data.CommonPrefixes[1].Prefix).to.equal('mix/');
 			expect(data.IsTruncated).to.equal(true);
-			expect(data.Marker).to.exist;
+			expect(data.Marker).to.not.exist;
+			expect(data.NextMarker).to.exist;
 
-			marker = data.Marker;
+			marker = data.NextMarker;
 
 			done();
 		});
@@ -120,8 +126,9 @@ describe('S3 with defaultOptions', function () {
 			expect(data.CommonPrefixes[1].Prefix).to.equal('river/');
 			expect(data.IsTruncated).to.equal(true);
 			expect(data.Marker).to.exist;
+			expect(data.NextMarker).to.exist;
 
-			marker = data.Marker;
+			marker = data.NextMarker;
 
 			done();
 		});
@@ -142,9 +149,10 @@ describe('S3 with defaultOptions', function () {
 			expect(data.CommonPrefixes[1].Prefix).to.exist;
 			expect(data.CommonPrefixes[1].Prefix).to.equal('sea/');
 			expect(data.IsTruncated).to.equal(false);
-			expect(data.Marker).to.not.exist;
+			expect(data.Marker).to.exist;
+			expect(data.NextMarker).to.not.exist;
 
-			marker = data.Marker;
+			marker = data.NextMarker;
 
 			done();
 		});


### PR DESCRIPTION
According to the spec for List Objects  http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html, in the response:
`Marker` - Indicates where in the bucket listing begins. `Marker` is included in the response if it was sent with the request. 
`NextMarker` - When response is truncated (the `IsTruncated` element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. 
Note: This (`NextMarker`) element is returned only if you have delimiter request parameter specified. If response does not include the `NextMaker` and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys.

Previously this module set the `Marker` to what should have been `NextMarker`. `NextMarker` is now set properly and `Marker` is set to what was sent in the request, thus this fix is a **breaking change**.