### PR TITLE
Static basePath configuration and bound parameters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,14 @@ module.exports = function(grunt) {
           reporter: 'spec'
         },
         src: ['test/testDefaultOptions.js']
+      },
+      testBasePath: {
+        options: {
+          reporter: 'spec'
+        },
+        src: ['test/testBasePath.js']
       }
+
     },
     clean: {
       test: ['test/local/**']
@@ -55,6 +62,6 @@ module.exports = function(grunt) {
 
   // By default, lint and run all tests.
   grunt.registerTask('lint', 'jshint');
-  grunt.registerTask('default', ['clean', 'copy', 'mochaTest:test', 'clean', 'copy', 'mochaTest:testDefaultOptions']);
+  grunt.registerTask('default', ['clean', 'copy', 'mochaTest:test', 'clean', 'copy', 'mochaTest:testDefaultOptions','clean', 'copy', 'mochaTest:testBasePath']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,12 @@ module.exports = function(grunt) {
         },
         src: ['test/testDefaultOptions.js']
       },
+      testDefaultOptionsAndBasePath: {
+        options: {
+          reporter: 'spec'
+        },
+        src: ['test/testDefaultOptionsBasePath.js']
+      },
       testBasePath: {
         options: {
           reporter: 'spec'
@@ -62,6 +68,6 @@ module.exports = function(grunt) {
 
   // By default, lint and run all tests.
   grunt.registerTask('lint', 'jshint');
-  grunt.registerTask('default', ['clean', 'copy', 'mochaTest:test', 'clean', 'copy', 'mochaTest:testDefaultOptions','clean', 'copy', 'mochaTest:testBasePath']);
+  grunt.registerTask('default', ['clean', 'copy', 'mochaTest:test', 'clean', 'copy', 'mochaTest:testDefaultOptions','clean', 'copy', 'mochaTest:testBasePath','clean', 'copy', 'mochaTest:testDefaultOptionsAndBasePath']);
 
 };

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -58,7 +58,8 @@ FakeStream.prototype.createReadStream = function () {
 
 /** Mocks key pieces of the amazon s3 sdk */
 function S3Mock(options) {
-	this.defaultOptions = _.extend({}, options);
+    if(!_.isUndefined(options) && !_.isUndefined(options.params))
+      this.defaultOptions = _.extend({}, applyBasePath(options.params));
 	this.config = {
 		update: function() {}
 	};

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -15,7 +15,7 @@ var path = require('path');
 var Buffer = require('buffer').Buffer;
 
 var defaultOptions = {
-  copySource: ''
+  copySourcePrefix: ''
 };
 // Gathered from http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
 function walk (dir) {
@@ -49,7 +49,7 @@ FakeStream.prototype.createReadStream = function () {
 
 /** Mocks key pieces of the amazon s3 sdk */
 function S3Mock(options) {
-	this.defaultOptions = _.extend(defaultOptions, options);
+	this.defaultOptions = _.extend({}, defaultOptions, options);
 	this.config = {
 		update: function() {}
 	};
@@ -202,7 +202,7 @@ S3Mock.prototype = {
 
 		fs.mkdirsSync(path.dirname(search.Bucket + '/' + search.Key));
 
-		fs.copy(decodeURIComponent(this.defaultOptions.copySource+search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
+		fs.copy(decodeURIComponent(this.defaultOptions.copySourcePrefix+search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
 
 			callback(err, search);
 		});

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -14,6 +14,9 @@ var crypto = require('crypto');
 var path = require('path');
 var Buffer = require('buffer').Buffer;
 
+var defaultOptions = {
+  copySource: ''
+};
 // Gathered from http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
 function walk (dir) {
 
@@ -46,7 +49,7 @@ FakeStream.prototype.createReadStream = function () {
 
 /** Mocks key pieces of the amazon s3 sdk */
 function S3Mock(options) {
-	this.defaultOptions = options;
+	this.defaultOptions = _.extend(defaultOptions, options);
 	this.config = {
 		update: function() {}
 	};
@@ -199,7 +202,7 @@ S3Mock.prototype = {
 
 		fs.mkdirsSync(path.dirname(search.Bucket + '/' + search.Key));
 
-		fs.copy(decodeURIComponent(search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
+		fs.copy(decodeURIComponent(this.defaultOptions.copySource+search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
 
 			callback(err, search);
 		});
@@ -247,6 +250,7 @@ S3Mock.prototype = {
 
 };
 
+exports.defaultOptions = defaultOptions;
 exports.S3 = function (options) {
 	return new S3Mock(options);
 };

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -14,9 +14,7 @@ var crypto = require('crypto');
 var path = require('path');
 var Buffer = require('buffer').Buffer;
 
-var defaultOptions = {
-  copySourcePrefix: ''
-};
+var config = {};
 // Gathered from http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
 function walk (dir) {
 
@@ -39,6 +37,17 @@ function walk (dir) {
 	return results;
 }
 
+/** Add basePath to selected keys */
+function applyBasePath(search) {
+  if(_.isUndefined(config.basePath)) return search;
+  var modifyKeys = ['Bucket', 'CopySource'];
+  var ret = _.mapObject(search, function(value, key) {
+    if(_.indexOf(modifyKeys, key) === -1) return value;
+    return config.basePath + '/' + value;
+  });
+  return ret;
+}
+
 /** FakeStream object for mocking S3 streams */
 function FakeStream (search) {
     this.src = search.Bucket + '/' + search.Key;
@@ -49,14 +58,14 @@ FakeStream.prototype.createReadStream = function () {
 
 /** Mocks key pieces of the amazon s3 sdk */
 function S3Mock(options) {
-	this.defaultOptions = _.extend({}, defaultOptions, options);
+	this.defaultOptions = _.extend({}, options);
 	this.config = {
 		update: function() {}
 	};
 }
 S3Mock.prototype = {
 	listObjects: function (search, callback) {
-		search = _.extend({}, this.defaultOptions, search);
+		search = _.extend({}, this.defaultOptions, applyBasePath(search));
 		var files = walk(search.Bucket);
 
 		var filtered_files = _.filter(files, function (file) { return !search.Prefix || file.replace(search.Bucket + '/', '').indexOf(search.Prefix) === 0; });
@@ -111,7 +120,7 @@ S3Mock.prototype = {
 	},
 
 	deleteObjects: function (search, callback) {
-		search = _.extend({}, this.defaultOptions, search);
+		search = _.extend({}, this.defaultOptions, applyBasePath(search));
 
 		var deleted = [];
 		var errors = [];
@@ -136,7 +145,7 @@ S3Mock.prototype = {
 	},
 
 	deleteObject: function (search, callback) {
-		search = _.extend({}, this.defaultOptions, search);
+		search = _.extend({}, this.defaultOptions, applyBasePath(search));
 
 		if (fs.existsSync(search.Bucket + '/' + search.Key)) {
 			fs.unlinkSync(search.Bucket + '/' + search.Key);
@@ -148,7 +157,7 @@ S3Mock.prototype = {
 	},
 
 	headObject: function (search, callback) {
-		search = _.extend({}, this.defaultOptions, search);
+		search = _.extend({}, this.defaultOptions, applyBasePath(search));
 
 		if (!callback) {
 			return new FakeStream(search);
@@ -174,7 +183,7 @@ S3Mock.prototype = {
 	},
 
 	getObject: function (search, callback) {
-		search = _.extend({}, this.defaultOptions, search);
+		search = _.extend({}, this.defaultOptions, applyBasePath(search));
 
 		if (!callback) {
 			return new FakeStream(search);
@@ -198,18 +207,18 @@ S3Mock.prototype = {
 	},
 
 	copyObject: function (search, callback) {
-		search = _.extend({}, this.defaultOptions, search);
+		search = _.extend({}, this.defaultOptions, applyBasePath(search));
 
 		fs.mkdirsSync(path.dirname(search.Bucket + '/' + search.Key));
 
-		fs.copy(decodeURIComponent(this.defaultOptions.copySourcePrefix+search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
+		fs.copy(decodeURIComponent(search.CopySource), search.Bucket + '/' + search.Key, function (err, data) {
 
 			callback(err, search);
 		});
 	},
 
 	putObject: function (search, callback) {
-		search = _.extend({}, this.defaultOptions, search);
+		search = _.extend({}, this.defaultOptions, applyBasePath(search));
 
 		var dest = search.Bucket + '/' + search.Key;
 
@@ -250,7 +259,7 @@ S3Mock.prototype = {
 
 };
 
-exports.defaultOptions = defaultOptions;
+exports.config = config;
 exports.S3 = function (options) {
 	return new S3Mock(options);
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "underscore": "1.5.2",
+    "underscore": "1.8.3",
     "fs-extra": "0.6.4"
   },
   "devDependencies": {

--- a/test/testBasePath.js
+++ b/test/testBasePath.js
@@ -2,17 +2,15 @@ var expect = require('chai').expect;
 var AWS = require('../');
 var fs = require('fs');
 
-describe('S3 with defaultOptions', function () {
+describe('S3', function () {
 
-	var s3 = AWS.S3({
-		Bucket: __dirname + '/local/otters',
-        Delimiter: '/',
-	});
+    AWS.config.basePath = __dirname + '/local/';
+	var s3 = AWS.S3();
 	var marker = null;
 
 	it('should list files in bucket with less than 1000 objects and use Prefix to filter', function (done) {
 
-		s3.listObjects({Prefix: 'sea/'}, function (err, data) {
+		s3.listObjects({Prefix: 'sea/', Bucket: 'otters'}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(560);
@@ -31,7 +29,7 @@ describe('S3 with defaultOptions', function () {
 
 	it('should list files in bucket with less than 1000 objects and use Prefix to filter - 2', function (done) {
 
-		s3.listObjects({Prefix: 'river/'}, function (err, data) {
+		s3.listObjects({Prefix: 'river/', Bucket: 'otters'}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(912);
@@ -50,7 +48,8 @@ describe('S3 with defaultOptions', function () {
 
 	it('should list files in bucket with more than 1000 objects and use Prefix to filter - 3', function (done) {
 
-		s3.listObjects({Prefix: 'mix/'}, function (err, data) {
+		s3.listObjects({Prefix: 'mix/', Bucket: 'otters', Delimiter:'/'},
+                               function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -69,7 +68,8 @@ describe('S3 with defaultOptions', function () {
 
 	it('should list files starting a marker with a partial filename', function (done) {
 
-		s3.listObjects({Prefix: '',  Marker: 'mix/yay copy 10' }, function (err, data) {
+		s3.listObjects({Prefix: '', Bucket: 'otters',  Marker: 'mix/yay copy 10',
+                                Delimiter:'/' }, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -88,7 +88,7 @@ describe('S3 with defaultOptions', function () {
 
 	it('should list all files in bucket (more than 1000)', function (done) {
 
-		s3.listObjects({Prefix: ''}, function (err, data) {
+		s3.listObjects({Prefix: '', Bucket: 'otters', Delimiter:'/'}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -112,7 +112,8 @@ describe('S3 with defaultOptions', function () {
 
 	it('should list more files in bucket (more than 1000) with marker', function (done) {
 
-		s3.listObjects({Prefix: '', Marker: marker}, function (err, data) {
+		s3.listObjects({Prefix: '', Marker: marker, Bucket: 'otters', Delimiter:'/'},
+                               function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -136,7 +137,8 @@ describe('S3 with defaultOptions', function () {
 
 	it('should list more files in bucket (more than 1000) with marker - 2', function (done) {
 
-		s3.listObjects({Prefix: '', Marker: marker}, function (err, data) {
+		s3.listObjects({Prefix: '', Marker: marker, Bucket: 'otters', Delimiter:'/'},
+                               function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(947);
@@ -158,13 +160,33 @@ describe('S3 with defaultOptions', function () {
 		});
 	});
 
+	it('should list all files in bucket (more than 1000) with no Prefix specified', function (done) {
+
+		s3.listObjects({Bucket: 'otters'}, function (err, data) {
+
+			expect(err).to.equal(null);
+			expect(data.Contents.length).to.equal(1000);
+			expect(data.Contents[1].ETag).to.exist;
+			expect(data.Contents[1].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
+			expect(data.Contents[1].Key).to.exist;
+			expect(data.CommonPrefixes.length).to.equal(2);
+			expect(data.CommonPrefixes[0].Prefix).to.exist;
+			expect(data.CommonPrefixes[0].Prefix).to.equal('/');
+			expect(data.CommonPrefixes[1].Prefix).to.exist;
+			expect(data.CommonPrefixes[1].Prefix).to.equal('mix/');
+			expect(data.IsTruncated).to.equal(true);
+
+			done();
+		});
+	});
+
 	it('should delete the specified file', function (done) {
 
 		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy.txt')).to.equal(true);
 
 		var to_delete = {
 			Key: '/sea/yo copy.txt',
-
+			Bucket: 'otters'
 		};
 
 		s3.deleteObject(to_delete, function (err, data) {
@@ -173,7 +195,7 @@ describe('S3 with defaultOptions', function () {
 			expect(data).to.exist;
 			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy.txt')).to.equal(false);
 
-			s3.listObjects({Prefix: 'sea'}, function (err, data) {
+			s3.listObjects({Prefix: 'sea', Bucket: 'otters'}, function (err, data) {
 
 				expect(err).to.equal(null);
 				expect(data.Contents.length).to.equal(559);
@@ -190,13 +212,13 @@ describe('S3 with defaultOptions', function () {
 		});
 	});
 
-    it('should fail to delete a file that does not exist', function (done) {
+  it('should not error when deleting a file that does not exist', function (done) {
 
 		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 20000.txt')).to.equal(false);
 
 		var to_delete = {
 			Key: '/sea/yo copy 20000.txt',
-
+			Bucket: 'otters'
 		};
 
 		s3.deleteObject(to_delete, function (err, data) {
@@ -226,7 +248,7 @@ describe('S3 with defaultOptions', function () {
 			Delete: {
 				Objects: keys
 			},
-
+			Bucket: 'otters'
 		};
 
 		s3.deleteObjects(to_delete, function (err, data) {
@@ -240,7 +262,7 @@ describe('S3 with defaultOptions', function () {
 			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 4.txt')).to.equal(false);
 			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 5.txt')).to.equal(false);
 
-			s3.listObjects({Prefix: 'sea'}, function (err, data) {
+			s3.listObjects({Prefix: 'sea', Bucket: 'otters'}, function (err, data) {
 
 				expect(err).to.equal(null);
 				expect(data.Contents.length).to.equal(555);
@@ -275,7 +297,7 @@ describe('S3 with defaultOptions', function () {
 			Delete: {
 				Objects: keys
 			},
-
+			Bucket: 'otters'
 		};
 
 		s3.deleteObjects(to_delete, function (err, data) {
@@ -298,7 +320,7 @@ describe('S3 with defaultOptions', function () {
 
 	it('should get the metadata about a file', function (done) {
 
-		s3.headObject({Key: 'animal.txt'}, function (err, data) {
+		s3.headObject({Key: 'animal.txt', Bucket: 'otters'}, function (err, data) {
 
 			expect(err).to.be.null;
 			expect(data.ETag).to.equal('"485737f20ae6c0c3e51f68dd9b93b4e9"');
@@ -309,7 +331,7 @@ describe('S3 with defaultOptions', function () {
 
 	it('should include a 404 statusCode for the metadata of a non-existant file', function (done) {
 
-		s3.headObject({Key: 'doesnt-exist.txt'}, function (err, data) {
+		s3.headObject({Key: 'doesnt-exist.txt', Bucket: 'otters'}, function (err, data) {
 
 			expect(err).to.not.be.null;
 			expect(err.statusCode).to.equal(404);
@@ -319,7 +341,7 @@ describe('S3 with defaultOptions', function () {
 
 	it('should get a file', function (done) {
 
-		s3.getObject({Key: 'sea/yo copy 10.txt'}, function (err, data) {
+		s3.getObject({Key: 'sea/yo copy 10.txt', Bucket: 'otters'}, function (err, data) {
 
 			expect(err).to.be.null;
 			expect(data.ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
@@ -330,7 +352,7 @@ describe('S3 with defaultOptions', function () {
 
 	it('should get a file and its content', function (done) {
 
-		s3.getObject({Key: 'animal.txt'}, function (err, data) {
+		s3.getObject({Key: 'animal.txt', Bucket: 'otters'}, function (err, data) {
 
 			var expectedBody = "My favourite animal";
 			expect(err).to.be.null;
@@ -344,12 +366,12 @@ describe('S3 with defaultOptions', function () {
 
 	it('should create a file and have the same content in sub dir', function (done) {
 
-		s3.putObject({Key: 'punk/file', Body: fs.readFileSync(__dirname + '/local/file')}, function (err, data) {
+		s3.putObject({Key: 'punk/file', Body: fs.readFileSync(__dirname + '/local/file'), Bucket: 'otters'}, function (err, data) {
 
 			expect(err).to.be.null;
 			expect(fs.existsSync(__dirname + '/local/otters/punk/file')).to.equal(true);
 
-			s3.getObject({Key: 'punk/file'}, function (err, data) {
+			s3.getObject({Key: 'punk/file', Bucket: 'otters'}, function (err, data) {
 
 				expect(err).to.be.null;
 				expect(data.Key).to.equal('punk/file');
@@ -361,11 +383,11 @@ describe('S3 with defaultOptions', function () {
 
 	it('should be able to put a string', function(done) {
 
-		s3.putObject({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}'}, function(err, data) {
+		s3.putObject({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}', Bucket: 'otters'}, function(err, data) {
 			expect(err).to.be.null;
 			expect(fs.existsSync(__dirname + '/local/otters/animal.json')).to.equal(true);
 
-			s3.getObject({Key: 'animal.json'}, function(err, data) {
+			s3.getObject({Key: 'animal.json', Bucket: 'otters'}, function(err, data) {
 
 				expect(err).to.be.null;
 				expect(data.Key).to.equal('animal.json');
@@ -375,48 +397,33 @@ describe('S3 with defaultOptions', function () {
 		})
 	});
 
+	it('should be able to upload a string', function(done) {
+
+		s3.upload({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true,"upload":true}', Bucket: 'otters'}, function(err, data) {
+			expect(err).to.be.null;
+			expect(fs.existsSync(__dirname + '/local/otters/animal.json')).to.equal(true);
+
+			s3.getObject({Key: 'animal.json', Bucket: 'otters'}, function(err, data) {
+
+				expect(err).to.be.null;
+				expect(data.Key).to.equal('animal.json');
+				expect(data.Body.toString()).to.equal('{"is dog":false,"name":"otter","stringified object?":true,"upload":true}');
+				done();
+			})
+		})
+	});
+
+    it('should be able to copy an object', function(done) {
+        s3.copyObject({ Key: 'animal_copy.txt', Bucket: 'otters', CopySource: 'otters/animal.txt' }, function(err, data) {
+			expect(err).to.be.null;
+			expect(fs.existsSync(__dirname + '/local/otters/animal_copy.txt')).to.equal(true);
+            done();
+        });
+    });
+
 	it('should accept "configuration"', function() {
 		expect(s3.config).to.be.ok;
 		expect(s3.config.update).to.be.a('function');
 	});
-    
-});
-
-
-describe('Multiple S3 with defaultOptions', function () {
-
-	var s3_1 = AWS.S3({
-		Bucket: __dirname + '/local/concurrent1'
-	});
-	var s3_2 = AWS.S3({
-		Bucket: __dirname + '/local/concurrent2'
-	});
-
-	it('should use different defaults', function(done) {
-
-		s3_1.putObject({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}'}, function(err, data) {
-			expect(err).to.be.null;
-			expect(fs.existsSync(__dirname + '/local/concurrent1/animal.json')).to.equal(true);
-
-			s3_2.putObject({Key: 'animal.json', Body: '{"is dog":true,"name":"snoopy","stringified object?":true}'}, function(err, data) {
-				expect(err).to.be.null;
-				expect(fs.existsSync(__dirname + '/local/concurrent2/animal.json')).to.equal(true);
-
-				s3_1.getObject({Key: 'animal.json'}, function(err, data) {
-					expect(err).to.be.null;
-					expect(data.Key).to.equal('animal.json');
-					expect(data.Body.toString()).to.equal('{"is dog":false,"name":"otter","stringified object?":true}');
-
-					s3_2.getObject({Key: 'animal.json'}, function(err, data) {
-						expect(err).to.be.null;
-						expect(data.Key).to.equal('animal.json');
-						expect(data.Body.toString()).to.equal('{"is dog":true,"name":"snoopy","stringified object?":true}');
-						done();
-					});
-				});
-			});
-		})
-	});
 
 });
-

--- a/test/testDefaultOptions.js
+++ b/test/testDefaultOptions.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 
 describe('S3 with defaultOptions', function () {
 
+    //AWS.defaultOptions.copySource = __dirname + '/local/';
 	var s3 = AWS.S3({
 		Bucket: __dirname + '/local/otters',
                 Delimiter: '/'
@@ -380,6 +381,15 @@ describe('S3 with defaultOptions', function () {
 		expect(s3.config.update).to.be.a('function');
 	});
 
+    /*
+    it('should be able to copy an object', function(done) {
+        s3.copyObject({ Key: 'file_copy', CopySource: 'file' }, function(err, data) {
+            console.log(err);
+			expect(err).to.be.null;
+			expect(fs.existsSync(__dirname + '/local/otters/file_copy')).to.equal(true);
+        });
+    });
+    */
 });
 
 

--- a/test/testDefaultOptions.js
+++ b/test/testDefaultOptions.js
@@ -4,9 +4,11 @@ var fs = require('fs');
 
 describe('S3 with defaultOptions', function () {
 
-	var s3 = AWS.S3({
+    var s3 = AWS.S3({ 
+      params: {
 		Bucket: __dirname + '/local/otters',
         Delimiter: '/',
+      }
 	});
 	var marker = null;
 
@@ -385,11 +387,15 @@ describe('S3 with defaultOptions', function () {
 
 describe('Multiple S3 with defaultOptions', function () {
 
-	var s3_1 = AWS.S3({
+    var s3_1 = AWS.S3({ 
+      params: {
 		Bucket: __dirname + '/local/concurrent1'
+      }
 	});
 	var s3_2 = AWS.S3({
+      params: {
 		Bucket: __dirname + '/local/concurrent2'
+      }
 	});
 
 	it('should use different defaults', function(done) {

--- a/test/testDefaultOptions.js
+++ b/test/testDefaultOptions.js
@@ -4,10 +4,14 @@ var fs = require('fs');
 
 describe('S3 with defaultOptions', function () {
 
-    //AWS.defaultOptions.copySource = __dirname + '/local/';
+    //AWS.defaultOptions can be used to set defaultOptions on S3 instance instead of using the constructor options parameter
+    //AWS.defaultOptions.copySourcePrefix = __dirname + '/local/';
+    //AWS.defaultOptions.Bucket = __dirname + '/local/otters';
+    //AWS.defaultOptions.Delimiter = '/';
 	var s3 = AWS.S3({
 		Bucket: __dirname + '/local/otters',
-                Delimiter: '/'
+        Delimiter: '/',
+        copySourcePrefix: __dirname + '/local/'
 	});
 	var marker = null;
 
@@ -381,15 +385,15 @@ describe('S3 with defaultOptions', function () {
 		expect(s3.config.update).to.be.a('function');
 	});
 
-    /*
+    
     it('should be able to copy an object', function(done) {
         s3.copyObject({ Key: 'file_copy', CopySource: 'file' }, function(err, data) {
-            console.log(err);
 			expect(err).to.be.null;
 			expect(fs.existsSync(__dirname + '/local/otters/file_copy')).to.equal(true);
+            done();
         });
     });
-    */
+    
 });
 
 

--- a/test/testDefaultOptionsBasePath.js
+++ b/test/testDefaultOptionsBasePath.js
@@ -2,15 +2,20 @@ var expect = require('chai').expect;
 var AWS = require('../');
 var fs = require('fs');
 
-describe('S3 with baseBath', function () {
+describe('S3 with defaultOptions and basePath', function () {
 
     AWS.config.basePath = __dirname + '/local/';
-	var s3 = AWS.S3();
+    var s3 = AWS.S3({ 
+      params: {
+		Bucket: 'otters',
+        Delimiter: '/',
+      }
+	});
 	var marker = null;
 
 	it('should list files in bucket with less than 1000 objects and use Prefix to filter', function (done) {
 
-		s3.listObjects({Prefix: 'sea/', Bucket: 'otters'}, function (err, data) {
+		s3.listObjects({Prefix: 'sea/'}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(560);
@@ -29,7 +34,7 @@ describe('S3 with baseBath', function () {
 
 	it('should list files in bucket with less than 1000 objects and use Prefix to filter - 2', function (done) {
 
-		s3.listObjects({Prefix: 'river/', Bucket: 'otters'}, function (err, data) {
+		s3.listObjects({Prefix: 'river/'}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(912);
@@ -48,8 +53,7 @@ describe('S3 with baseBath', function () {
 
 	it('should list files in bucket with more than 1000 objects and use Prefix to filter - 3', function (done) {
 
-		s3.listObjects({Prefix: 'mix/', Bucket: 'otters', Delimiter:'/'},
-                               function (err, data) {
+		s3.listObjects({Prefix: 'mix/'}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -68,8 +72,7 @@ describe('S3 with baseBath', function () {
 
 	it('should list files starting a marker with a partial filename', function (done) {
 
-		s3.listObjects({Prefix: '', Bucket: 'otters',  Marker: 'mix/yay copy 10',
-                                Delimiter:'/' }, function (err, data) {
+		s3.listObjects({Prefix: '',  Marker: 'mix/yay copy 10' }, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -88,7 +91,7 @@ describe('S3 with baseBath', function () {
 
 	it('should list all files in bucket (more than 1000)', function (done) {
 
-		s3.listObjects({Prefix: '', Bucket: 'otters', Delimiter:'/'}, function (err, data) {
+		s3.listObjects({Prefix: ''}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -112,8 +115,7 @@ describe('S3 with baseBath', function () {
 
 	it('should list more files in bucket (more than 1000) with marker', function (done) {
 
-		s3.listObjects({Prefix: '', Marker: marker, Bucket: 'otters', Delimiter:'/'},
-                               function (err, data) {
+		s3.listObjects({Prefix: '', Marker: marker}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(1000);
@@ -137,8 +139,7 @@ describe('S3 with baseBath', function () {
 
 	it('should list more files in bucket (more than 1000) with marker - 2', function (done) {
 
-		s3.listObjects({Prefix: '', Marker: marker, Bucket: 'otters', Delimiter:'/'},
-                               function (err, data) {
+		s3.listObjects({Prefix: '', Marker: marker}, function (err, data) {
 
 			expect(err).to.equal(null);
 			expect(data.Contents.length).to.equal(947);
@@ -160,33 +161,13 @@ describe('S3 with baseBath', function () {
 		});
 	});
 
-	it('should list all files in bucket (more than 1000) with no Prefix specified', function (done) {
-
-		s3.listObjects({Bucket: 'otters'}, function (err, data) {
-
-			expect(err).to.equal(null);
-			expect(data.Contents.length).to.equal(1000);
-			expect(data.Contents[1].ETag).to.exist;
-			expect(data.Contents[1].ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
-			expect(data.Contents[1].Key).to.exist;
-			expect(data.CommonPrefixes.length).to.equal(2);
-			expect(data.CommonPrefixes[0].Prefix).to.exist;
-			expect(data.CommonPrefixes[0].Prefix).to.equal('/');
-			expect(data.CommonPrefixes[1].Prefix).to.exist;
-			expect(data.CommonPrefixes[1].Prefix).to.equal('mix/');
-			expect(data.IsTruncated).to.equal(true);
-
-			done();
-		});
-	});
-
 	it('should delete the specified file', function (done) {
 
 		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy.txt')).to.equal(true);
 
 		var to_delete = {
 			Key: '/sea/yo copy.txt',
-			Bucket: 'otters'
+
 		};
 
 		s3.deleteObject(to_delete, function (err, data) {
@@ -195,7 +176,7 @@ describe('S3 with baseBath', function () {
 			expect(data).to.exist;
 			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy.txt')).to.equal(false);
 
-			s3.listObjects({Prefix: 'sea', Bucket: 'otters'}, function (err, data) {
+			s3.listObjects({Prefix: 'sea'}, function (err, data) {
 
 				expect(err).to.equal(null);
 				expect(data.Contents.length).to.equal(559);
@@ -212,13 +193,13 @@ describe('S3 with baseBath', function () {
 		});
 	});
 
-  it('should not error when deleting a file that does not exist', function (done) {
+    it('should fail to delete a file that does not exist', function (done) {
 
 		expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 20000.txt')).to.equal(false);
 
 		var to_delete = {
 			Key: '/sea/yo copy 20000.txt',
-			Bucket: 'otters'
+
 		};
 
 		s3.deleteObject(to_delete, function (err, data) {
@@ -248,7 +229,7 @@ describe('S3 with baseBath', function () {
 			Delete: {
 				Objects: keys
 			},
-			Bucket: 'otters'
+
 		};
 
 		s3.deleteObjects(to_delete, function (err, data) {
@@ -262,7 +243,7 @@ describe('S3 with baseBath', function () {
 			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 4.txt')).to.equal(false);
 			expect(fs.existsSync(__dirname + '/local/otters/sea/yo copy 5.txt')).to.equal(false);
 
-			s3.listObjects({Prefix: 'sea', Bucket: 'otters'}, function (err, data) {
+			s3.listObjects({Prefix: 'sea'}, function (err, data) {
 
 				expect(err).to.equal(null);
 				expect(data.Contents.length).to.equal(555);
@@ -297,7 +278,7 @@ describe('S3 with baseBath', function () {
 			Delete: {
 				Objects: keys
 			},
-			Bucket: 'otters'
+
 		};
 
 		s3.deleteObjects(to_delete, function (err, data) {
@@ -320,7 +301,7 @@ describe('S3 with baseBath', function () {
 
 	it('should get the metadata about a file', function (done) {
 
-		s3.headObject({Key: 'animal.txt', Bucket: 'otters'}, function (err, data) {
+		s3.headObject({Key: 'animal.txt'}, function (err, data) {
 
 			expect(err).to.be.null;
 			expect(data.ETag).to.equal('"485737f20ae6c0c3e51f68dd9b93b4e9"');
@@ -331,7 +312,7 @@ describe('S3 with baseBath', function () {
 
 	it('should include a 404 statusCode for the metadata of a non-existant file', function (done) {
 
-		s3.headObject({Key: 'doesnt-exist.txt', Bucket: 'otters'}, function (err, data) {
+		s3.headObject({Key: 'doesnt-exist.txt'}, function (err, data) {
 
 			expect(err).to.not.be.null;
 			expect(err.statusCode).to.equal(404);
@@ -341,7 +322,7 @@ describe('S3 with baseBath', function () {
 
 	it('should get a file', function (done) {
 
-		s3.getObject({Key: 'sea/yo copy 10.txt', Bucket: 'otters'}, function (err, data) {
+		s3.getObject({Key: 'sea/yo copy 10.txt'}, function (err, data) {
 
 			expect(err).to.be.null;
 			expect(data.ETag).to.equal('"d41d8cd98f00b204e9800998ecf8427e"');
@@ -352,7 +333,7 @@ describe('S3 with baseBath', function () {
 
 	it('should get a file and its content', function (done) {
 
-		s3.getObject({Key: 'animal.txt', Bucket: 'otters'}, function (err, data) {
+		s3.getObject({Key: 'animal.txt'}, function (err, data) {
 
 			var expectedBody = "My favourite animal";
 			expect(err).to.be.null;
@@ -366,12 +347,12 @@ describe('S3 with baseBath', function () {
 
 	it('should create a file and have the same content in sub dir', function (done) {
 
-		s3.putObject({Key: 'punk/file', Body: fs.readFileSync(__dirname + '/local/file'), Bucket: 'otters'}, function (err, data) {
+		s3.putObject({Key: 'punk/file', Body: fs.readFileSync(__dirname + '/local/file')}, function (err, data) {
 
 			expect(err).to.be.null;
 			expect(fs.existsSync(__dirname + '/local/otters/punk/file')).to.equal(true);
 
-			s3.getObject({Key: 'punk/file', Bucket: 'otters'}, function (err, data) {
+			s3.getObject({Key: 'punk/file'}, function (err, data) {
 
 				expect(err).to.be.null;
 				expect(data.Key).to.equal('punk/file');
@@ -383,11 +364,11 @@ describe('S3 with baseBath', function () {
 
 	it('should be able to put a string', function(done) {
 
-		s3.putObject({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}', Bucket: 'otters'}, function(err, data) {
+		s3.putObject({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}'}, function(err, data) {
 			expect(err).to.be.null;
 			expect(fs.existsSync(__dirname + '/local/otters/animal.json')).to.equal(true);
 
-			s3.getObject({Key: 'animal.json', Bucket: 'otters'}, function(err, data) {
+			s3.getObject({Key: 'animal.json'}, function(err, data) {
 
 				expect(err).to.be.null;
 				expect(data.Key).to.equal('animal.json');
@@ -397,33 +378,53 @@ describe('S3 with baseBath', function () {
 		})
 	});
 
-	it('should be able to upload a string', function(done) {
-
-		s3.upload({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true,"upload":true}', Bucket: 'otters'}, function(err, data) {
-			expect(err).to.be.null;
-			expect(fs.existsSync(__dirname + '/local/otters/animal.json')).to.equal(true);
-
-			s3.getObject({Key: 'animal.json', Bucket: 'otters'}, function(err, data) {
-
-				expect(err).to.be.null;
-				expect(data.Key).to.equal('animal.json');
-				expect(data.Body.toString()).to.equal('{"is dog":false,"name":"otter","stringified object?":true,"upload":true}');
-				done();
-			})
-		})
-	});
-
-    it('should be able to copy an object', function(done) {
-        s3.copyObject({ Key: 'animal_copy.txt', Bucket: 'otters', CopySource: 'otters/animal.txt' }, function(err, data) {
-			expect(err).to.be.null;
-			expect(fs.existsSync(__dirname + '/local/otters/animal_copy.txt')).to.equal(true);
-            done();
-        });
-    });
-
 	it('should accept "configuration"', function() {
 		expect(s3.config).to.be.ok;
 		expect(s3.config.update).to.be.a('function');
 	});
+    
+});
+
+
+describe('Multiple S3 with defaultOptions', function () {
+
+    AWS.config.basePath = __dirname + '/local/';
+    var s3_1 = AWS.S3({ 
+      params: {
+		Bucket: 'concurrent1'
+      }
+	});
+	var s3_2 = AWS.S3({
+      params: {
+		Bucket: 'concurrent2'
+      }
+	});
+
+	it('should use different defaults', function(done) {
+
+		s3_1.putObject({Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}'}, function(err, data) {
+			expect(err).to.be.null;
+			expect(fs.existsSync(__dirname + '/local/concurrent1/animal.json')).to.equal(true);
+
+			s3_2.putObject({Key: 'animal.json', Body: '{"is dog":true,"name":"snoopy","stringified object?":true}'}, function(err, data) {
+				expect(err).to.be.null;
+				expect(fs.existsSync(__dirname + '/local/concurrent2/animal.json')).to.equal(true);
+
+				s3_1.getObject({Key: 'animal.json'}, function(err, data) {
+					expect(err).to.be.null;
+					expect(data.Key).to.equal('animal.json');
+					expect(data.Body.toString()).to.equal('{"is dog":false,"name":"otter","stringified object?":true}');
+
+					s3_2.getObject({Key: 'animal.json'}, function(err, data) {
+						expect(err).to.be.null;
+						expect(data.Key).to.equal('animal.json');
+						expect(data.Body.toString()).to.equal('{"is dog":true,"name":"snoopy","stringified object?":true}');
+						done();
+					});
+				});
+			});
+		})
+	});
 
 });
+

--- a/undefined/animal.json
+++ b/undefined/animal.json
@@ -1,0 +1,1 @@
+{"is dog":false,"name":"otter","stringified object?":true}


### PR DESCRIPTION
*The original PR has been changed*

In this PR
* Added a static property to the module named "config".
It can be used like this:

```javascript
AWS.config.basePath = '/tmp/testfiles/';
var s3 = AWS.S3();
//This will create the file /tmp/testfiles/awesomebucket/file.txt
s3.putObject({Bucket: 'awesomebucket', Key: 'file.txt', Body: 'Some text' }, function(err, data) {});
```
* The current functionality with defaultOptions has changed from:
```javascript
var s3 = AWS.S3({ Bucket: '...' });
```
to:
```javascript
var s3 = AWS.S3({params: {Bucket: '...'}})
``` 
It will also work with config.basePath:
```javascript
AWS.config.basePath = '/tmp/testfiles/';
var s3 = AWS.S3({params: {Bucket: 'awesomebucket'}});
//This will create the file /tmp/testfiles/awesomebucket/file.txt
s3.putObject({Key: 'file.txt', Body: 'Some text' }, function(err, data) {});
```
Fixes issue #18 

* Added a test suite using config.basePath and a test for copyObject
* Modified the testDefaultOptions test to use bund parameters instead, real AWS.S3 can not be called without a Bucket key (unless it has been bound).
* Added a test suite using config.basePath combined with bound parameters
* Updated underscore to the latest version (for `_.mapObject`)


Thanks for doing this module, it's exactly what i needed!
