### PR TITLE
fix listObjects() marker implementation

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -118,8 +118,8 @@ S3Mock.prototype = {
 		};
 
 		if (search.Marker) {
-                        result.Marker = search.Marker;
-                }
+			result.Marker = search.Marker;
+		}
 		if (truncated && search.Delimiter) {
 			result.NextMarker = _.last(result.Contents).Key;
 		}

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -74,11 +74,18 @@ S3Mock.prototype = {
 		var truncated = false;
 
 		if (search.Marker) {
-			var startFile = _(filtered_files).find(function(file) { return file.indexOf(search.Bucket  + '/' + search.Marker) === 0; });
+			var markerFile = _(filtered_files).find(function(file) {
+				return file.indexOf(search.Bucket  + '/' + search.Marker) === 0;
+			});
+			var startFile = filtered_files[filtered_files.indexOf(markerFile) + 1];
 			start = filtered_files.indexOf(startFile);
 		}
 
-		filtered_files = _.rest(filtered_files, start);
+		if (start == -1) {
+		  filtered_files = [];
+		} else {
+		  filtered_files = _.rest(filtered_files, start);
+		}
 
 		if (filtered_files.length > 1000) {
 			truncated = true;

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -74,10 +74,20 @@ S3Mock.prototype = {
 		var truncated = false;
 
 		if (search.Marker) {
+			var isPartial;
 			var markerFile = _(filtered_files).find(function(file) {
-				return file.indexOf(search.Bucket  + '/' + search.Marker) === 0;
+			var marker = search.Bucket  + '/' + search.Marker;
+			if (file.indexOf(marker) === 0) {
+			  isPartial = file.length == marker.length ? false : true;
+			  return true;
+			}
 			});
-			var startFile = filtered_files[filtered_files.indexOf(markerFile) + 1];
+			var startFile;
+			if (isPartial) {
+				startFile = filtered_files[filtered_files.indexOf(markerFile)];
+			} else {
+				startFile = filtered_files[filtered_files.indexOf(markerFile) + 1];
+			}
 			start = filtered_files.indexOf(startFile);
 		}
 


### PR DESCRIPTION
When using the `marker` option with `s3.listObjects()`, only objects after the marker should be returned.  Can I assume `filtered_files` is in alphabetical order?

> Marker
Specifies the key to start with when listing objects in a bucket. Amazon S3 returns object keys in alphabetical order, starting with key after the marker in order.

http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html