### PR TITLE
Include Size attribute for listObjects method

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -127,11 +127,14 @@ S3Mock.prototype = {
 
 		var result = {
 			Contents: _.map(filtered_files, function (path) {
+				
+				var stat = fs.statSync(path);
 
 				return {
 					Key: path.replace(search.Bucket + '/', ''),
 					ETag: '"' + crypto.createHash('md5').update(fs.readFileSync(path)).digest('hex') + '"',
-					LastModified: fs.statSync(path).mtime
+					LastModified: stat.mtime,
+					Size: stat.size
 				};
 			}),
 			CommonPrefixes: _.reduce(filtered_files, function (prefixes, path) {


### PR DESCRIPTION
I needed "Size" as part of the return value from listObjects. It's part of the official S3 API too, see: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#listObjects-property