### PR TITLE
fix: file not found exception on getObject

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -245,6 +245,16 @@ S3Mock.prototype = {
 					});
 				}
 				else {
+					if (err.code === "ENOENT") {
+						return callback({
+							cfId: undefined,
+							code: "NoSuchKey",
+							message: "The specified key does not exist.",
+							name: "NoSuchKey",
+							region: null,
+							statusCode: 404
+						}, search);
+					}
 					callback(err, search);
 				}
 			});


### PR DESCRIPTION
With this fix, the getObject() function answers correctly if called on a non-existing object. Please note, that not the full answer is included, just the fields that may be interesting in testing situations, such as "code", "message", "name" and "statusCode".