### PR TITLE
Add support for object tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Available:
 - headObject
 - putObject
 - copyObject
+- getObjectTagging
+- putObjectTagging
 - upload
 
 It uses a directory to mock a bucket and its content.

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -410,7 +410,7 @@ S3Mock.prototype = {
 		}
 	},
 
-	getObjectTagging(search, callback) {
+	getObjectTagging: function (search, callback) {
 		var self = this;
 
 		this.headObject(search, function(err, props) {
@@ -425,7 +425,7 @@ S3Mock.prototype = {
 		})
 	},
 
-	putObjectTagging(search, callback) {
+	putObjectTagging: function (search, callback) {
 		var self = this;
 
 		if (!search.Tagging || !search.Tagging.TagSet) {

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -81,6 +81,7 @@ function S3Mock(options) {
 
 S3Mock.prototype = {
 	objectMetadataDictionary : [],
+	objectTaggingDictionary : [],
 
 	listObjects: function (search, callback) {
 
@@ -338,7 +339,26 @@ S3Mock.prototype = {
 		if (search.Metadata) {
 			this.objectMetadataDictionary[search.Key] = search.Metadata;
 		}
-		
+
+		if (typeof search.Tagging === 'string') {
+			// URL query parameter encoded
+			var tags = {};
+			var tagSet = [];
+			// quick'n'dirty parsing into an object (does not support hashes or arrays)
+			search.Tagging.split('&').forEach(function(part) {
+				var item = part.split('=');
+				tags[decodeURIComponent(item[0])] = decodeURIComponent(item[1]);
+			});
+			// expand into tagset
+			Object.keys(tags).forEach(function(key) {
+				tagSet.push({
+					Key: key,
+					Value: tags[key]
+				});
+			});
+			this.objectTaggingDictionary[search.Key] = tagSet;
+		}
+
 		var dest = search.Bucket + '/' + search.Key;
 
 		var sendCallback = null;
@@ -388,6 +408,40 @@ S3Mock.prototype = {
 				sendCallback = cb;
 			}
 		}
+	},
+
+	getObjectTagging(search, callback) {
+		var self = this;
+
+		this.headObject(search, function(err, props) {
+			if (err) {
+				return callback(err);
+			} else {
+				return callback(null, {
+					VersionId: '1',
+					TagSet: self.objectTaggingDictionary[search.Key] || []
+				});
+			}
+		})
+	},
+
+	putObjectTagging(search, callback) {
+		var self = this;
+
+		if (!search.Tagging || !search.Tagging.TagSet) {
+			return callback(new Error('Tagging.TagSet required'))
+		}
+
+		this.headObject(search, function(err, props) {
+			if (err) {
+				return callback(err);
+			} else {
+				self.objectTaggingDictionary[search.Key] = search.Tagging.TagSet;
+				return callback(null, {
+					VersionId: '1'
+				});
+			}
+		})
 	},
 
 	upload: function (search, options, callback) {

--- a/test/test.js
+++ b/test/test.js
@@ -500,9 +500,70 @@ describe('S3', function () {
 		});
 	});
 
+	it('should be able to put an object with tagging and retrieve them afterwards', function(done) {
+
+		s3.putObject({
+			Key: 'animal.json', Body: '{"is dog":false,"name":"otter","stringified object?":true}',
+			Bucket: __dirname + '/local/otters',
+			Tagging: 'tag1=test1&tag2=test2'
+		}, function(err, data) {
+			expect(err).to.be.null;
+
+			s3.getObjectTagging({Key: 'animal.json', Bucket: __dirname + '/local/otters'}, function(err, data) {
+
+				expect(err).to.be.null;
+				expect(data.TagSet).to.deep.equal([
+					{ Key: 'tag1', Value: 'test1' },
+					{ Key: 'tag2', Value: 'test2' }
+				]);
+				done();
+			});
+		});
+	});
+
+	it('should fail to put object tags against a non-existing object', function(done) {
+		s3.putObjectTagging({Key: 'does-not-exist', Bucket: __dirname + '/local/otters',
+			Tagging: { TagSet: [] }
+		}, function(err, data) {
+			expect(err).to.not.be.null;
+			expect(err.statusCode).to.equal(404);
+			done();
+		});
+	});
+
+	it('should put object tags against an existing object', function(done) {
+		s3.putObjectTagging({Key: 'animal.txt', Bucket: __dirname + '/local/otters',
+		  Tagging: { TagSet: [ { Key: 'type', Value: 'otter' }] }
+		}, function(err, data) {
+			expect(err).to.be.null;
+			expect(data).to.not.be.null
+			done();
+		});
+	});
+
+	it('should get object tags from an existing object', function(done) {
+		s3.getObjectTagging({Key: 'animal.txt', Bucket: __dirname + '/local/otters'}, function(err, data) {
+			expect(err).to.be.null;
+			expect(data).to.not.be.null
+			expect(data.TagSet).to.deep.equal([
+				{ Key: 'type', Value: 'otter' }
+			])
+			done();
+		});
+	});
+
+	it('should fail to get object tags from a non-existing object', function(done) {
+		s3.getObjectTagging({Key: 'does-not-exist', Bucket: __dirname + '/local/otters'}, function(err, data) {
+			expect(err).to.not.be.null;
+			expect(err.statusCode).to.equal(404);
+			done();
+		});
+	});
+
+
+
 	it('should accept "configuration"', function() {
 		expect(s3.config).to.be.ok;
 		expect(s3.config.update).to.be.a('function');
 	});
-
 });


### PR DESCRIPTION
Hi @MathieuLoutre 

Thanks for this library! I've found myself needing to mock object tagging and the `listObjectsV2` endpoint, so I've implemented support for them.

This PR contains the object tagging support. As with metadata, these are only stored in-memory.