### PR TITLE
Add support for listObjectsV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a very simple interface that mocks the AWS SDK for Node.js. The implemen
 Available:
 - createBucket
 - listObjects
+- listObjectsV2
 - deleteObjects
 - deleteObject
 - getObject

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -82,6 +82,22 @@ function S3Mock(options) {
 S3Mock.prototype = {
 	objectMetadataDictionary : [],
 
+	listObjectsV2: function (searchV2, callback) {
+		var searchV1 = _(searchV2).clone()
+		// Marker in V1 is StartAfter in V2
+		// ContinuationToken trumps marker on subsequent requests.
+		searchV1.Marker = searchV2.ContinuationToken || searchV2.StartAfter
+		this.listObjects(searchV1, function (err, resultV1) {
+			var resultV2 = _(resultV1).clone()
+			// Rewrite NextMarker to NextContinuationToken
+			resultV2.NextContinuationToken = resultV1.NextMarker
+			// Remember original ContinuationToken and StartAfter
+			resultV2.ContinuationToken = searchV2.ContinuationToken
+			resultV2.StartAfter = searchV2.StartAfter
+			callback(err, resultV2)
+		})
+	},
+
 	listObjects: function (search, callback) {
 
 		search = _.extend({}, this.defaultOptions, applyBasePath(search));


### PR DESCRIPTION
Hi @MathieuLoutre 

This PR contains the `listObjectsV2` support. It's built on top of `listObjects` and translates the relevant parameters to/from the old model.

This might be incomplete, but works for my use case.