### PR TITLE
Support `tags` option in `upload`

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -532,7 +532,32 @@ S3Mock.prototype = {
 			options = null;
 		}
 
-		return this.putObject(search, callback);
+		if (options && options.tags) {
+			if (!Array.isArray(options.tags)) {
+				return callback(new Error('Tags must be specified as an array; ' + typeof options.tags + ' provided'));
+			}
+		}
+
+		return this.putObject(search, function (err, data) {
+			if (options && options.tags) {
+				// https://github.com/aws/aws-sdk-js/pull/1425
+				return this.putObjectTagging({
+					Bucket: search.Bucket,
+					Key: search.Key,
+					Tagging: {
+						TagSet: options.tags
+					}
+				}, function (err) {
+					if (err) {
+						return callback(err);
+					}
+
+					return callback(null, data);
+				});
+			}
+
+			return callback(null, data);
+		}.bind(this));
 	}
 
 };

--- a/test/test.js
+++ b/test/test.js
@@ -712,6 +712,24 @@ describe('S3', function () {
 			.catch(done);
     });
 
+    it('should be able to tag uploads using tags option', function(done) {
+		var key = 'tagging-' + Math.random();
+		var bucket = __dirname + '/local/tags';
+		var tags = [ { Key: 'foo', Value: 'bar' } ];
+		s3.upload({Key: key, Bucket: bucket, Body: 'stuff'}, {tags: tags}, function(err, data) {
+			expect(err).to.be.null;
+
+			s3.getObjectTagging({Key: key, Bucket: bucket}, function(err, data) {
+				expect(err).to.be.null;
+				expect(data.TagSet).to.deep.equal([
+					{ Key: 'foo', Value: 'bar' }
+				]);
+
+				done();
+			});
+		});
+    });
+
     it('should be able to put an object with tagging and retrieve them afterwards', function(done) {
 
 		s3.putObject({


### PR DESCRIPTION
This is sadly not well documented in the AWS SDK, but is supported. This interface is necessary to ensure tags are applied to both single and multipart uploads.

See aws/aws-sdk-js#1425