### PR TITLE
Ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ logs
 results
 
 npm-debug.log
+yarn.lock
 
 node_modules
 /test/local


### PR DESCRIPTION
This makes it explicit that npm's package-lock.json is to be used instead of yarn. Ignoring yarn.lock means that mock-aws-s3 devs can still install dependencies with yarn if they want, the resulting yarn.lock file just won't be checked in.