### PR TITLE
Faster travis builds with `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 
 node_js:


### PR DESCRIPTION
This enables building in a container instead of a full VM.