### PR TITLE
Recreate package-lock to fix install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,68 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+      "dev": true
+    },
+    "async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "chai": {
       "version": "1.7.2",
@@ -16,13 +74,115 @@
       "dev": true,
       "requires": {
         "assertion-error": "1.0.0"
+      }
+    },
+    "cli": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
+      "integrity": "sha1-5oGcjV+qlX9k+Y9mqFBiaMHR8X0=",
+      "dev": true,
+      "requires": {
+        "glob": ">= 3.1.4"
+      }
+    },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz",
+      "integrity": "sha1-Suc/Gu6Nb89ITxoc53zmUdm38Mk=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dev": true,
+      "requires": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
       },
       "dependencies": {
-        "assertion-error": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
-          "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
         }
       }
     },
@@ -31,33 +191,54 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.6.4.tgz",
       "integrity": "sha1-9G8MdbeEH40gCzNIzU1pHVoJnRU=",
       "requires": {
-        "jsonfile": "1.0.1",
-        "mkdirp": "0.3.5",
-        "ncp": "0.4.2",
-        "rimraf": "2.2.8"
+        "jsonfile": "~1.0.1",
+        "mkdirp": "0.3.x",
+        "ncp": "~0.4.2",
+        "rimraf": "~2.2.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
       },
       "dependencies": {
-        "jsonfile": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.0.1.tgz",
-          "integrity": "sha1-6l7+QLg2kLmGZ2FKc5L8YOhCwN0="
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-        },
-        "ncp": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-          "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
         }
       }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto=",
+      "dev": true
     },
     "grunt": {
       "version": "0.4.5",
@@ -65,327 +246,26 @@
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "coffee-script": "1.3.3",
-        "colors": "0.6.2",
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
         "dateformat": "1.0.2-1.2.3",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.1.3",
-        "getobject": "0.1.0",
-        "glob": "3.1.21",
-        "grunt-legacy-log": "0.1.3",
-        "grunt-legacy-util": "0.2.0",
-        "hooker": "0.2.3",
-        "iconv-lite": "0.2.11",
-        "js-yaml": "2.0.5",
-        "lodash": "0.9.2",
-        "minimatch": "0.2.14",
-        "nopt": "1.0.10",
-        "rimraf": "2.2.8",
-        "underscore.string": "2.2.1",
-        "which": "1.0.9"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
-          "dev": true
-        },
-        "coffee-script": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-          "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
-          "dev": true
-        },
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-          "dev": true
-        },
-        "dateformat": {
-          "version": "1.0.2-1.2.3",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
-          "dev": true
-        },
-        "eventemitter2": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
-          "dev": true
-        },
-        "exit": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-          "dev": true
-        },
-        "findup-sync": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-          "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
-          "dev": true,
-          "requires": {
-            "glob": "3.2.11",
-            "lodash": "2.4.2"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "3.2.11",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-              "dev": true,
-              "requires": {
-                "inherits": "2.0.1",
-                "minimatch": "0.3.0"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-                  "dev": true
-                },
-                "minimatch": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                  "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-                  "dev": true,
-                  "requires": {
-                    "lru-cache": "2.7.3",
-                    "sigmund": "1.0.1"
-                  },
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-                      "dev": true
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-              "dev": true
-            }
-          }
-        },
-        "getobject": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-          "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
-          "dev": true
-        },
-        "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-              "dev": true
-            },
-            "inherits": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-              "dev": true
-            }
-          }
-        },
-        "grunt-legacy-log": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
-          "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
-          "dev": true,
-          "requires": {
-            "colors": "0.6.2",
-            "grunt-legacy-log-utils": "0.1.1",
-            "hooker": "0.2.3",
-            "lodash": "2.4.2",
-            "underscore.string": "2.3.3"
-          },
-          "dependencies": {
-            "grunt-legacy-log-utils": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
-              "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
-              "dev": true,
-              "requires": {
-                "colors": "0.6.2",
-                "lodash": "2.4.2",
-                "underscore.string": "2.3.3"
-              }
-            },
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-              "dev": true
-            },
-            "underscore.string": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-              "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-              "dev": true
-            }
-          }
-        },
-        "grunt-legacy-util": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
-          "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
-          "dev": true,
-          "requires": {
-            "async": "0.1.22",
-            "exit": "0.1.2",
-            "getobject": "0.1.0",
-            "hooker": "0.2.3",
-            "lodash": "0.9.2",
-            "underscore.string": "2.2.1",
-            "which": "1.0.9"
-          }
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.2.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-          "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
-          "dev": true,
-          "requires": {
-            "argparse": "0.1.16",
-            "esprima": "1.0.4"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "0.1.16",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-              "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-              "dev": true,
-              "requires": {
-                "underscore": "1.7.0",
-                "underscore.string": "2.4.0"
-              },
-              "dependencies": {
-                "underscore": {
-                  "version": "1.7.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-                  "dev": true
-                },
-                "underscore.string": {
-                  "version": "2.4.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
-                  "dev": true
-                }
-              }
-            },
-            "esprima": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-              "dev": true
-            },
-            "sigmund": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-              "dev": true
-            }
-          }
-        },
-        "nopt": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.0.7"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
-              "dev": true
-            }
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-          "dev": true
-        }
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
       }
     },
     "grunt-contrib-clean": {
@@ -394,15 +274,7 @@
       "integrity": "sha1-9T397ghJsce0Dp67umn0jExgecU=",
       "dev": true,
       "requires": {
-        "rimraf": "2.2.8"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        }
+        "rimraf": "~2.2.1"
       }
     },
     "grunt-contrib-copy": {
@@ -417,174 +289,74 @@
       "integrity": "sha1-JHECpl5QfyFEdZfvDuwzwcmfrg8=",
       "dev": true,
       "requires": {
-        "jshint": "1.0.0"
+        "jshint": "~1.0.0"
+      }
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
-        "jshint": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-1.0.0.tgz",
-          "integrity": "sha1-3NW3rfd2qfZRl5kLYfz6caMlbwM=",
-          "dev": true,
-          "requires": {
-            "cli": "0.4.3",
-            "esprima": "https://github.com/ariya/esprima/tarball/master",
-            "minimatch": "0.4.0",
-            "peakle": "0.0.1",
-            "shelljs": "0.5.3",
-            "underscore": "1.8.3"
-          },
-          "dependencies": {
-            "cli": {
-              "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
-              "integrity": "sha1-5oGcjV+qlX9k+Y9mqFBiaMHR8X0=",
-              "dev": true,
-              "requires": {
-                "glob": "6.0.4"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "6.0.4",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                  "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-                  "dev": true,
-                  "requires": {
-                    "inflight": "1.0.4",
-                    "inherits": "2.0.1",
-                    "minimatch": "3.0.0",
-                    "once": "1.3.3",
-                    "path-is-absolute": "1.0.0"
-                  },
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
-                      "dev": true,
-                      "requires": {
-                        "once": "1.3.3",
-                        "wrappy": "1.0.1"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-                      "dev": true
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                      "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
-                      "dev": true,
-                      "requires": {
-                        "brace-expansion": "1.1.2"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.2",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                          "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
-                          "dev": true,
-                          "requires": {
-                            "balanced-match": "0.3.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                              "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
-                              "dev": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                      "dev": true,
-                      "requires": {
-                        "wrappy": "1.0.1"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "esprima": {
-              "version": "https://github.com/ariya/esprima/tarball/master",
-              "integrity": "sha1-bHPBW4ecASoi7Y7VsYZjLoMnzNI=",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
-              "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
-              "dev": true,
-              "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
-              },
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-                  "dev": true
-                },
-                "sigmund": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-                  "dev": true
-                }
-              }
-            },
-            "peakle": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/peakle/-/peakle-0.0.1.tgz",
-              "integrity": "sha1-KGRF1qdzPxfcJzUB4uA5n0G4kOA=",
-              "dev": true
-            },
-            "shelljs": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-              "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
-              "dev": true
-            }
-          }
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
         }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true,
+      "requires": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
       }
     },
     "grunt-mocha-test": {
@@ -593,8 +365,123 @@
       "integrity": "sha1-VIeJ+GviS6omSrfJikQsBbLbb5g=",
       "dev": true,
       "requires": {
-        "mocha": "1.12.1"
+        "mocha": "~1.12.0"
       }
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      }
+    },
+    "jshint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-1.0.0.tgz",
+      "integrity": "sha1-3NW3rfd2qfZRl5kLYfz6caMlbwM=",
+      "dev": true,
+      "requires": {
+        "cli": "0.4.3",
+        "esprima": "https://github.com/ariya/esprima/tarball/master",
+        "minimatch": "0.x.x",
+        "peakle": "*",
+        "shelljs": "*",
+        "underscore": "*"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "https://github.com/ariya/esprima/tarball/master",
+          "integrity": "sha512-SVdIGYq0LOpiY9XZtA0lQW2/2yaylJnn/PCoHxQcPHljkT9L80Q8LOIyOMptNhDd53mOxRaStBofT7zPRozRsA==",
+          "dev": true
+        }
+      }
+    },
+    "jsonfile": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.0.1.tgz",
+      "integrity": "sha1-6l7+QLg2kLmGZ2FKc5L8YOhCwN0="
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
     },
     "mocha": {
       "version": "1.12.1",
@@ -603,128 +490,167 @@
       "dev": true,
       "requires": {
         "commander": "0.6.1",
-        "debug": "2.2.0",
+        "debug": "*",
         "diff": "1.0.2",
         "glob": "3.2.1",
-        "growl": "1.7.0",
+        "growl": "1.7.x",
         "jade": "0.26.3",
         "mkdirp": "0.3.5"
       },
       "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
-          }
-        },
-        "diff": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz",
-          "integrity": "sha1-Suc/Gu6Nb89ITxoc53zmUdm38Mk=",
-          "dev": true
-        },
         "glob": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.1.tgz",
           "integrity": "sha1-V69w7HO6IyO/4/KaBndl22TF11g=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-              "dev": true
-            },
-            "inherits": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "0.2.14",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-              "dev": true,
-              "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
-              },
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-                  "dev": true
-                },
-                "sigmund": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-                  "dev": true
-                }
-              }
-            }
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           }
         },
-        "growl": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
-          "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto=",
-          "dev": true
-        },
-        "jade": {
-          "version": "0.26.3",
-          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-          "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-          "dev": true,
-          "requires": {
-            "commander": "0.6.1",
-            "mkdirp": "0.3.0"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-              "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-              "dev": true
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         }
       }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "ncp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "peakle": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/peakle/-/peakle-0.0.1.tgz",
+      "integrity": "sha1-KGRF1qdzPxfcJzUB4uA5n0G4kOA=",
+      "dev": true
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+    },
+    "shelljs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
     },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }


### PR DESCRIPTION
The version of esprima in the existing package-lock.json is failing integrity checks.