### PR TITLE
Fix Request's createReadStream

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -84,6 +84,12 @@ function createPromisable(wrapped) {
 		}
 		if (!_.isFunction(callback)) {
 			return {
+				createReadStream: function () {
+					var sent = this.send();
+					if (sent instanceof FakeStream) {
+						return this.send().createReadStream()
+					}
+				},
 				promise: function () {
 					return promisified(search, options);
 				},
@@ -91,7 +97,7 @@ function createPromisable(wrapped) {
 					if (!_.isObject(options)) {
 						options = cb;
 					}
-					wrapped.apply(self, [search, options, cb]);
+					return wrapped.apply(self, [search, options, cb]);
 				}
 			};
 		} else {

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -85,9 +85,9 @@ function createPromisable(wrapped) {
 		if (!_.isFunction(callback)) {
 			return {
 				createReadStream: function () {
-					var sent = this.send();
-					if (sent instanceof FakeStream) {
-						return this.send().createReadStream()
+					this.send();
+					if (this._returned instanceof FakeStream) {
+						return this._returned.createReadStream();
 					}
 				},
 				promise: function () {
@@ -97,7 +97,7 @@ function createPromisable(wrapped) {
 					if (!_.isObject(options)) {
 						options = cb;
 					}
-					return wrapped.apply(self, [search, options, cb]);
+					this._returned = wrapped.apply(self, [search, options, cb]);
 				}
 			};
 		} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,42 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -26,15 +62,88 @@
         }
       }
     },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "https://github.com/ariya/esprima/tarball/master",
+      "integrity": "sha512-NpIIa83N47pO8m01O9ja94K9aaU8suEP+Z5w+cFzahlrCDw+dESpBpfwrqJI0RFDaAW+gJYsxZSc4T/amhR56Q==",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dev": true,
+      "requires": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        }
+      }
+    },
     "fs-extra": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.6.4.tgz",
       "integrity": "sha1-9G8MdbeEH40gCzNIzU1pHVoJnRU=",
       "requires": {
-        "jsonfile": "1.0.1",
-        "mkdirp": "0.3.5",
-        "ncp": "0.4.2",
-        "rimraf": "2.2.8"
+        "jsonfile": "~1.0.1",
+        "mkdirp": "0.3.x",
+        "ncp": "~0.4.2",
+        "rimraf": "~2.2.0"
       },
       "dependencies": {
         "jsonfile": {
@@ -59,333 +168,63 @@
         }
       }
     },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
     "grunt": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "coffee-script": "1.3.3",
-        "colors": "0.6.2",
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
         "dateformat": "1.0.2-1.2.3",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.1.3",
-        "getobject": "0.1.0",
-        "glob": "3.1.21",
-        "grunt-legacy-log": "0.1.3",
-        "grunt-legacy-util": "0.2.0",
-        "hooker": "0.2.3",
-        "iconv-lite": "0.2.11",
-        "js-yaml": "2.0.5",
-        "lodash": "0.9.2",
-        "minimatch": "0.2.14",
-        "nopt": "1.0.10",
-        "rimraf": "2.2.8",
-        "underscore.string": "2.2.1",
-        "which": "1.0.9"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
-          "dev": true
-        },
-        "coffee-script": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-          "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
-          "dev": true
-        },
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-          "dev": true
-        },
-        "dateformat": {
-          "version": "1.0.2-1.2.3",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
-          "dev": true
-        },
-        "eventemitter2": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
-          "dev": true
-        },
-        "exit": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-          "dev": true
-        },
-        "findup-sync": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-          "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
-          "dev": true,
-          "requires": {
-            "glob": "3.2.11",
-            "lodash": "2.4.2"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "3.2.11",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-              "dev": true,
-              "requires": {
-                "inherits": "2.0.1",
-                "minimatch": "0.3.0"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-                  "dev": true
-                },
-                "minimatch": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                  "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-                  "dev": true,
-                  "requires": {
-                    "lru-cache": "2.7.3",
-                    "sigmund": "1.0.1"
-                  },
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-                      "dev": true
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-              "dev": true
-            }
-          }
-        },
-        "getobject": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-          "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
-          "dev": true
-        },
-        "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-              "dev": true
-            },
-            "inherits": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-              "dev": true
-            }
-          }
-        },
-        "grunt-legacy-log": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
-          "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
-          "dev": true,
-          "requires": {
-            "colors": "0.6.2",
-            "grunt-legacy-log-utils": "0.1.1",
-            "hooker": "0.2.3",
-            "lodash": "2.4.2",
-            "underscore.string": "2.3.3"
-          },
-          "dependencies": {
-            "grunt-legacy-log-utils": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
-              "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
-              "dev": true,
-              "requires": {
-                "colors": "0.6.2",
-                "lodash": "2.4.2",
-                "underscore.string": "2.3.3"
-              }
-            },
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-              "dev": true
-            },
-            "underscore.string": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-              "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-              "dev": true
-            }
-          }
-        },
-        "grunt-legacy-util": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
-          "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
-          "dev": true,
-          "requires": {
-            "async": "0.1.22",
-            "exit": "0.1.2",
-            "getobject": "0.1.0",
-            "hooker": "0.2.3",
-            "lodash": "0.9.2",
-            "underscore.string": "2.2.1",
-            "which": "1.0.9"
-          }
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.2.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-          "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
-          "dev": true,
-          "requires": {
-            "argparse": "0.1.16",
-            "esprima": "1.0.4"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "0.1.16",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-              "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-              "dev": true,
-              "requires": {
-                "underscore": "1.7.0",
-                "underscore.string": "2.4.0"
-              },
-              "dependencies": {
-                "underscore": {
-                  "version": "1.7.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-                  "dev": true
-                },
-                "underscore.string": {
-                  "version": "2.4.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
-                  "dev": true
-                }
-              }
-            },
-            "esprima": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-              "dev": true
-            },
-            "sigmund": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-              "dev": true
-            }
-          }
-        },
-        "nopt": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.0.7"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
-              "dev": true
-            }
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-          "dev": true
-        }
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
       }
     },
     "grunt-contrib-clean": {
@@ -394,7 +233,7 @@
       "integrity": "sha1-9T397ghJsce0Dp67umn0jExgecU=",
       "dev": true,
       "requires": {
-        "rimraf": "2.2.8"
+        "rimraf": "~2.2.1"
       },
       "dependencies": {
         "rimraf": {
@@ -417,7 +256,7 @@
       "integrity": "sha1-JHECpl5QfyFEdZfvDuwzwcmfrg8=",
       "dev": true,
       "requires": {
-        "jshint": "1.0.0"
+        "jshint": "~1.0.0"
       },
       "dependencies": {
         "jshint": {
@@ -428,10 +267,10 @@
           "requires": {
             "cli": "0.4.3",
             "esprima": "https://github.com/ariya/esprima/tarball/master",
-            "minimatch": "0.4.0",
-            "peakle": "0.0.1",
-            "shelljs": "0.5.3",
-            "underscore": "1.8.3"
+            "minimatch": "0.x.x",
+            "peakle": "*",
+            "shelljs": "*",
+            "underscore": "*"
           },
           "dependencies": {
             "cli": {
@@ -440,7 +279,7 @@
               "integrity": "sha1-5oGcjV+qlX9k+Y9mqFBiaMHR8X0=",
               "dev": true,
               "requires": {
-                "glob": "6.0.4"
+                "glob": ">= 3.1.4"
               },
               "dependencies": {
                 "glob": {
@@ -449,11 +288,11 @@
                   "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.4",
-                    "inherits": "2.0.1",
-                    "minimatch": "3.0.0",
-                    "once": "1.3.3",
-                    "path-is-absolute": "1.0.0"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -462,8 +301,8 @@
                       "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
                       "dev": true,
                       "requires": {
-                        "once": "1.3.3",
-                        "wrappy": "1.0.1"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -486,7 +325,7 @@
                       "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.2"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -495,7 +334,7 @@
                           "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.3.0",
+                            "balanced-match": "^0.3.0",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -521,7 +360,7 @@
                       "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.1"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -542,19 +381,14 @@
                 }
               }
             },
-            "esprima": {
-              "version": "https://github.com/ariya/esprima/tarball/master",
-              "integrity": "sha1-bHPBW4ecASoi7Y7VsYZjLoMnzNI=",
-              "dev": true
-            },
             "minimatch": {
               "version": "0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
               "dev": true,
               "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               },
               "dependencies": {
                 "lru-cache": {
@@ -587,13 +421,138 @@
         }
       }
     },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true,
+      "requires": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      }
+    },
     "grunt-mocha-test": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.6.3.tgz",
       "integrity": "sha1-VIeJ+GviS6omSrfJikQsBbLbb5g=",
       "dev": true,
       "requires": {
-        "mocha": "1.12.1"
+        "mocha": "~1.12.0"
+      }
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "mocha": {
@@ -603,10 +562,10 @@
       "dev": true,
       "requires": {
         "commander": "0.6.1",
-        "debug": "2.2.0",
+        "debug": "*",
         "diff": "1.0.2",
         "glob": "3.2.1",
-        "growl": "1.7.0",
+        "growl": "1.7.x",
         "jade": "0.26.3",
         "mkdirp": "0.3.5"
       },
@@ -646,9 +605,9 @@
           "integrity": "sha1-V69w7HO6IyO/4/KaBndl22TF11g=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           },
           "dependencies": {
             "graceful-fs": {
@@ -669,8 +628,8 @@
               "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
               "dev": true,
               "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               },
               "dependencies": {
                 "lru-cache": {
@@ -721,10 +680,49 @@
         }
       }
     },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "stream-buffers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+      "dev": true
+    },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.2.0",
-    "grunt": "~0.4.0",
     "chai": "~1.7.2",
-    "mocha": "~1.12.1",
-    "grunt-mocha-test": "~0.6.3",
+    "grunt": "~0.4.0",
+    "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-clean": "~0.5.0"
+    "grunt-contrib-jshint": "~0.2.0",
+    "grunt-mocha-test": "~0.6.3",
+    "mocha": "~1.12.1",
+    "stream-buffers": "^3.0.2"
   },
   "keywords": [
     "aws",

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
 var expect = require('chai').expect;
 var AWS = require('../');
 var fs = require('fs');
+var streamBuffers = require('stream-buffers');
 
 describe('S3', function () {
 
@@ -625,6 +626,25 @@ describe('S3', function () {
 			expect(data.Key).to.equal('animal.txt');
 			expect(data.Body.toString()).to.equal(expectedBody);
 			expect(data.ContentLength).to.equal(expectedBody.length);
+			done();
+		});
+	});
+
+	it('should get a readable stream out of a file', function (done) {
+
+		var expectedBody = "My favourite animal";
+
+		var request = s3.getObject({ Key: 'animal.txt', Bucket: __dirname + '/local/otters' })
+
+		// Duck type-check the request object. It must have ALL of the following at least:
+		expect(request).to.have.property('promise');
+		expect(request).to.have.property('send');
+		expect(request).to.have.property('createReadStream');
+
+		// Dump the stream to a buffer to test it
+		const writableStream = new streamBuffers.WritableStreamBuffer();
+		request.createReadStream().pipe(writableStream).on('finish', function () {
+			expect(writableStream.getContentsAsString()).to.equal(expectedBody)
 			done();
 		});
 	});

--- a/test/testBasePath.js
+++ b/test/testBasePath.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var AWS = require('../');
 var fs = require('fs');
+var streamBuffers = require('stream-buffers');
 
 describe('S3 with baseBath', function () {
 
@@ -413,6 +414,27 @@ describe('S3 with baseBath', function () {
 			expect(data.Key).to.equal('animal.txt');
 			expect(data.Body.toString()).to.equal(expectedBody);
 			expect(data.ContentLength).to.equal(expectedBody.length);
+			done();
+		});
+	});
+
+	it('should get a readable stream out of a file', function (done) {
+
+		var expectedBody = "My favourite animal";
+
+		var request = s3.getObject({ Key: 'animal.txt', Bucket: 'otters' })
+
+		// Duck type-check the returned request object.
+		// It must have ALL of the following, at least:
+		expect(request).to.have.property('promise');
+		expect(request).to.have.property('send');
+		expect(request).to.have.property('createReadStream');
+
+		// Dump the stream to a buffer to test it
+		const readStream = request.createReadStream();
+		const writableStream = new streamBuffers.WritableStreamBuffer();
+		readStream.pipe(writableStream).on('finish', function () {
+			expect(writableStream.getContentsAsString()).to.equal(expectedBody)
 			done();
 		});
 	});

--- a/test/testDefaultOptions.js
+++ b/test/testDefaultOptions.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var AWS = require('../');
 var fs = require('fs');
+var streamBuffers = require('stream-buffers');
 
 describe('S3 with defaultOptions', function () {
 
@@ -391,6 +392,25 @@ describe('S3 with defaultOptions', function () {
 			expect(data.Key).to.equal('animal.txt');
 			expect(data.Body.toString()).to.equal(expectedBody);
 			expect(data.ContentLength).to.equal(expectedBody.length);
+			done();
+		});
+	});
+
+	it('should get a readable stream out of a file', function (done) {
+
+		var expectedBody = "My favourite animal";
+
+		var request = s3.getObject({ Key: 'animal.txt', Bucket: __dirname + '/local/otters' })
+
+		// Duck type-check the request object. It must have ALL of the following at least:
+		expect(request).to.have.property('promise');
+		expect(request).to.have.property('send');
+		expect(request).to.have.property('createReadStream');
+
+		// Dump the stream to a buffer to test it
+		const writableStream = new streamBuffers.WritableStreamBuffer();
+		request.createReadStream().pipe(writableStream).on('finish', function () {
+			expect(writableStream.getContentsAsString()).to.equal(expectedBody)
 			done();
 		});
 	});


### PR DESCRIPTION
Fixes #56.

This adds a createReadStream to the mock Request object returned by calling the endpoints. If the underlying implementation returns a FakeStream object (as getObject does) the method calls the matching method of FakeStream.

This fixes the scenario where getObject is called with no callback, and the returned request object is queried for a readable stream. Test are added for the scenario in order to avoid future regressions.
