### PR TITLE
Remove console.log in getSignedURL

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -604,7 +604,6 @@ S3Mock.prototype = {
 						callback(err, null)
 					}
 					else {
-						console.log('TEST')
 						callback(null, url)
 					}
 				}


### PR DESCRIPTION
As the title says, this PR removes an errant console.log statement that pollutes any tests which use `getSignedURL`.