### PR TITLE
Update underscore from 1.8.3 to 1.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2665,9 +2665,9 @@
       }
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "underscore.string": {
       "version": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "fs-extra": "^7.0.1",
-    "underscore": "1.8.3"
+    "underscore": "1.12.1"
   },
   "devDependencies": {
     "chai": "~1.7.2",


### PR DESCRIPTION
Snyk flagged the version of underscore as vulnerable to ACE: 
https://snyk.io/vuln/SNYK-JS-UNDERSCORE-1080984

It doesn't look like the vulnerable function (`template`, `templateSettings`) is being used here, so just a version bump should suffice