### PR TITLE
fix: upload() called with stream returns object not boolean

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -486,7 +486,7 @@ S3Mock.prototype = {
 			var stream = fs.createWriteStream(dest)
 
 			stream.on('finish', function () {
-				done(null, true)
+				done(null, { Location: dest, Key: search.Key, Bucket: search.Bucket })
 			})
 
 			search.Body.on('error', function (err) {


### PR DESCRIPTION
As per the title, `upload()` called with a stream should return an object, in the same way that it does if called with a buffer