### PR TITLE
fix: upload() called with stream returns object not boolean

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -106,6 +106,9 @@ function createPromisable (wrapped) {
 				send: function (cb) {
 					args.push(cb)
 					this._returned = wrapped.apply(self, args)
+				},
+				on: function (event, cb) {
+					cb({ total: 0 })
 				}
 			}
 		}

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -486,7 +486,7 @@ S3Mock.prototype = {
 			var stream = fs.createWriteStream(dest)
 
 			stream.on('finish', function () {
-				done(null, true)
+				done(null, { Location: dest, Key: search.Key, Bucket: search.Bucket })
 			})
 
 			search.Body.on('error', function (err) {


### PR DESCRIPTION
Update `upload()` called with a Stream response to be the same object as if `upload()` was called with a Buffer